### PR TITLE
fix: remove runtime relative deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ We can have two types of releases:
 - [ ] (Crate release only) Upload crates to `crates.io` using the commands below, replacing `XX` with your incremented
       version number:
       `cargo release 0.XX.0 -v --no-tag --no-push -p ink-node-runtime -p ink-parachain-runtime --execute`
-      `cargo release 0.XX.0 -v --no-tag --no-push -p ink-node --execute`
       Note: Before uploading, perform a dry run to ensure that it will be successful.
+- [ ] (Create release only) Upload the runtime dependencies in `ink-node` such that they depend on the published versions.
+        Then, release `ink-node`:
+        `cargo release 0.XX.0 -v --no-tag --no-push -p ink-node --execute`
+        Note: Before uploading, perform a dry run to ensure that it will be successful.
 - [ ] Merge the release PR branch.
 - [ ] Set the tag and run the following commands to push the tag. The tag must contain a message, otherwise the github action won't be able to create a release:
   

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,10 +27,8 @@ serde_json = { workspace = true }
 wasmtime = { workspace = true }
 
 # Local
-ink-parachain-runtime = { path = "../parachain-runtime", features = [
-  "parachain",
-], version = "0.43.0" }
-ink-node-runtime = { path = "../runtime", version = "0.43.0" }
+ink-parachain-runtime = { features = ["parachain"], version = "0.43.1" }
+ink-node-runtime = { version = "0.43.1" }
 
 # Substrate
 frame-benchmarking = { workspace = true }
@@ -99,10 +97,10 @@ substrate-build-script-utils = { workspace = true }
 default = []
 std = ["deranged/std"]
 runtime-benchmarks = [
-	"ink-parachain-runtime/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
+  "ink-parachain-runtime/runtime-benchmarks",
+  "polkadot-cli/runtime-benchmarks",
 ]
 try-runtime = [
-	"try-runtime-cli/try-runtime",
-	"ink-parachain-runtime/try-runtime",
+  "try-runtime-cli/try-runtime",
+  "ink-parachain-runtime/try-runtime",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,7 +26,7 @@ futures = { workspace = true }
 serde_json = { workspace = true }
 wasmtime = { workspace = true }
 
-# Local
+# ink-node runtimes
 ink-parachain-runtime = { features = ["parachain"], version = "0.43.1" }
 ink-node-runtime = { version = "0.43.1" }
 


### PR DESCRIPTION
Point `ink-parachain-runtime` and `ink-node-runtime` to the released versions.
By not pointing these crates to their published versions users will get warning messages like:
```
# warning: ink-parachain-runtime@0.43.1: Could not find `Cargo.lock` for `/usr/local/cargo/git/checkouts/ink-node-29da7d2edc1cd62e/fead45a/parachain-runtime/Cargo.toml`, while searching from `/tmp/cargo-installnFhLxY/release/build/ink-parachain-runtime-108aa76c7bd3d505/out`. To fix this, point the `WASM_BUILD_WORKSPACE_HINT` env variable to the directory of the workspace being compiled.   
 ```