### PR TITLE
chore: sync ink-node with latest polkadot-sdk main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 # common variable is defined in the workflow
 # repo env variable doesn't work for PR from forks
 env:
-  CI_IMAGE: "paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202506021710"
 
 jobs:
   set-image:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.target
+**/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-core"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+checksum = "5968f48d7a62587cd874bd84034831da4f7f577ce5de984828e376766efc0f32"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -125,15 +125,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "const-hex",
  "itoa",
  "serde",
  "serde_json",
@@ -142,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -154,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -164,14 +163,14 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -191,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -205,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -223,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
 dependencies = [
  "const-hex",
  "dunce",
@@ -239,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
 dependencies = [
  "serde",
  "winnow",
@@ -249,14 +248,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
- "const-hex",
  "serde",
 ]
 
@@ -434,7 +432,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -605,7 +603,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1218,9 +1216,8 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "181f5380e435b8ba6d901f8b16fc8908c6f0f8bea8973113d1c8718d89bb1809"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "hash-db",
  "log",
@@ -1477,14 +1474,13 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f093f70e1193363e778130745d9758044ae07267bc39a9ca4408144759babb"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
 ]
 
@@ -2269,28 +2265,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-client-bootnodes"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel 1.9.0",
+ "cumulus-client-network",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "hex",
+ "ip_network",
+ "log",
+ "num-traits",
+ "parachains-common",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build 0.13.5",
+ "sc-network 0.34.0",
+ "sc-service 0.35.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-runtime 31.0.1",
+ "tokio",
+]
+
+[[package]]
 name = "cumulus-client-cli"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2d80f117f1527a96c6153453886545e2d63be311eb85a3a2652fde2f493244"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "clap",
  "parity-scale-codec",
- "sc-chain-spec 42.0.0",
- "sc-cli 0.51.0",
- "sc-client-api 39.0.0",
- "sc-service 0.50.0",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sc-chain-spec 28.0.0",
+ "sc-cli 0.36.0",
+ "sc-client-api 28.0.0",
+ "sc-service 0.35.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6b29ec8e4279575eb2dae772ff12c85ba2f1c3eb9bbc6af4bd4f9479263a25"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2302,19 +2322,18 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sp-api 36.0.1",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sc-client-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a332c568f7804c5b8f6a9c8ffdb551fd4ab85f658917e7dc2d1b7338c5c7cc1"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2332,84 +2351,83 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-aura",
  "sc-consensus-babe",
  "sc-consensus-slots",
- "sc-telemetry 28.1.0",
- "sc-utils 18.0.1",
+ "sc-telemetry 15.0.0",
+ "sc-utils 14.0.0",
  "schnellru",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-aura 0.42.0",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-timestamp 36.0.0",
- "sp-trie 39.1.0",
- "substrate-prometheus-endpoint",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-timestamp 26.0.0",
+ "sp-trie 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbc413f1f48d1812e2bf580f22a41bd4c9575d78dd75b092b0c7587c1d36dee"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-streams",
  "dyn-clone",
  "futures",
  "log",
  "parity-scale-codec",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-babe",
+ "sc-network 0.34.0",
  "schnellru",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-timestamp 36.0.0",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
- "substrate-prometheus-endpoint",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-timestamp 26.0.0",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4a9da6c4c0869a75a26f0ba7d6a1c592cda5ab360c5602b493154195f96dfd"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
- "sp-consensus 0.42.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
+ "sp-consensus 0.32.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64938605e24f1416d422702088d75ade01a1ed6d90958d957f277e8e495c3d89"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2421,22 +2439,22 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-version 39.0.0",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-version 29.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4acde48ac4c352f41a1eef209a8bc7dd76d5d6dad2979aa6527678beda7b2f7"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2444,24 +2462,25 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
- "sp-crypto-hashing",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-storage 22.0.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus-babe",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-storage 19.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558118be0843a5a8ea5d89c004807ac3bbefe30954d775ef608ead946fd58c8e"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-streams",
  "futures",
  "futures-timer",
  "parity-scale-codec",
@@ -2470,22 +2489,23 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sp-api 36.0.1",
- "sp-consensus 0.42.0",
- "sp-maybe-compressed-blob",
- "sp-runtime 41.1.0",
- "sp-version 39.0.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-network 0.34.0",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f80077ecd00a08e419f1e931d815f46ff0325955e181ee048ae6a94b1c55b46c"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "async-channel 1.9.0",
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -2496,69 +2516,68 @@ dependencies = [
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
+ "cumulus-relay-chain-streams",
  "futures",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sc-network 0.49.1",
- "sc-network-sync 0.48.0",
- "sc-network-transactions 0.48.0",
- "sc-rpc 44.0.0",
- "sc-service 0.50.0",
- "sc-sysinfo 42.0.0",
- "sc-telemetry 28.1.0",
- "sc-transaction-pool 39.0.0",
- "sc-utils 18.0.1",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-transaction-pool 36.0.0",
+ "prometheus",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-network 0.34.0",
+ "sc-network-sync 0.33.0",
+ "sc-network-transactions 0.33.0",
+ "sc-rpc 29.0.0",
+ "sc-service 0.35.0",
+ "sc-sysinfo 27.0.0",
+ "sc-telemetry 15.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-utils 14.0.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-transaction-pool 26.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db210f52473f603bdb4c2f7919859e5ecae935ba674ac54b12b287615735907"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
- "sp-consensus-aura 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09617f1e8078715e34052581ec198a42944c971af4ac8482a7ba4d77f7ac25"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3eab3409f29ea088aa016e8e45e246d3630277c0e4b37d7c55aa5ef7aaab2a"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2567,8 +2586,9 @@ dependencies = [
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
+ "hashbrown 0.15.3",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
@@ -2576,15 +2596,16 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-std",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "trie-db 0.30.0",
@@ -2593,8 +2614,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbaf3a1ce23ac8476481484fef5f4d500cbd15b4dad6380ce1d28134b0c1f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2604,45 +2624,43 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48217a9e11b836fe5ccea6768e26bf628a574d2ae178f793d2f2b972c50da5de"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a322a86f98d2c7dfaaa787de92568cd776873dfa78339d27ccb14e85631838dc"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229345265f5551d2b0fdba0f44a1ef85c907b5f4cf47aefc70a17ca70538b719"
+version = "0.7.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "approx",
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-message-queue",
@@ -2650,9 +2668,9 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -2660,81 +2678,76 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae7651c74adc9785402c4b2e59a089b39b466c9e5628b92b1800063ecd5864d"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-api 36.0.1",
- "sp-consensus-aura 0.42.0",
+ "sp-api 26.0.0",
+ "sp-consensus-aura 0.32.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e219ac5b7cc1ec53c8c3fc01745ec28d77ddd845dc8b9c32e542d70f11888"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 36.0.1",
- "sp-runtime 41.1.0",
- "sp-trie 39.1.0",
+ "sp-api 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-trie 29.0.0",
  "staging-xcm",
+ "tracing",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c8bb6be20c760997a62ee067fc63be701b15cac32adc8526f0eefc4623a887"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-trie 39.1.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9230c15cefe5c80941ac287e3c6a900631de4d673ff167fe622f1698c97a845e"
+version = "0.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-externalities 0.30.0",
- "sp-runtime-interface 29.0.1",
- "sp-trie 39.1.0",
+ "sp-externalities 0.25.0",
+ "sp-runtime-interface 24.0.0",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-timestamp"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2c510928cf69deb096c6a487957f9b25b1dd05e5538c3eb572b153e893ee6e"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
- "sp-inherents 36.0.0",
- "sp-timestamp 36.0.0",
+ "sp-inherents 26.0.0",
+ "sp-timestamp 26.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075080c08260cf07ca74b2029039d81b84748d2e95dce3415c3ac5795494db18"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -2742,34 +2755,36 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54c77651716e7b8867bca186fec797491cbfd2b51b21c90fd1ada242237adfc"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "async-channel 1.9.0",
  "async-trait",
+ "cumulus-client-bootnodes",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
  "polkadot-cli",
+ "polkadot-primitives",
  "polkadot-service",
- "sc-cli 0.51.0",
- "sc-client-api 39.0.0",
- "sc-sysinfo 42.0.0",
- "sc-telemetry 28.1.0",
- "sc-tracing 39.0.0",
- "sp-api 36.0.1",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
+ "sc-cli 0.36.0",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-sysinfo 27.0.0",
+ "sc-telemetry 15.0.0",
+ "sc-tracing 28.0.0",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcdead0c8d5939349b712e863d6996459ddc2b2b021b1c1386dd5bcd0a1ac14"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2777,22 +2792,24 @@ dependencies = [
  "jsonrpsee-core 0.24.9",
  "parity-scale-codec",
  "polkadot-overseer",
- "sc-client-api 39.0.0",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-state-machine 0.45.0",
- "sp-version 39.0.0",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-version 29.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c6765ce2a83d194c4098e967e8087caf6233f5782b855fc9a721025084a2af"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
+ "async-channel 1.9.0",
  "async-trait",
+ "cumulus-client-bootnodes",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
@@ -2805,26 +2822,25 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-service",
  "sc-authority-discovery",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
- "sc-service 0.50.0",
- "sc-tracing 39.0.0",
- "sc-utils 18.0.1",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-babe 0.42.1",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
+ "sc-service 0.35.0",
+ "sc-tracing 28.0.0",
+ "sc-utils 14.0.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b918e3978be78a54cf84a33e8ddc4a6125b8eddb4db21d06ecb3d1f1ed69e6"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2838,22 +2854,23 @@ dependencies = [
  "polkadot-overseer",
  "prometheus",
  "rand 0.8.5",
- "sc-client-api 39.0.0",
- "sc-rpc-api 0.48.0",
- "sc-service 0.50.0",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-rpc-api 0.33.0",
+ "sc-service 0.35.0",
  "schnellru",
  "serde",
  "serde_json",
  "smoldot 0.11.0",
  "smoldot-light 0.9.0",
  "sp-authority-discovery",
- "sp-consensus-babe 0.42.1",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-storage 22.0.0",
- "sp-version 39.0.0",
- "substrate-prometheus-endpoint",
+ "sp-consensus-babe 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-storage 19.0.0",
+ "sp-version 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -2862,17 +2879,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-relay-chain-streams"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "cumulus-relay-chain-interface",
+ "futures",
+ "polkadot-node-subsystem",
+ "polkadot-primitives",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "tracing",
+]
+
+[[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1bf30f2eed8f8bfd89e65d52395d124d45caa4ccd90a7e1326bb2fb7ac347b2"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-trie 39.1.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
@@ -3195,7 +3225,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3610,16 +3639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethabi-decode"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52029c4087f9f01108f851d0d02df9c21feb5660a19713466724b7f95bd2d773"
-dependencies = [
- "ethereum-types",
- "tiny-keccak",
-]
-
-[[package]]
 name = "ethbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3651,14 @@ dependencies = [
  "impl-serde 0.5.0",
  "scale-info",
  "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-standards"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "alloy-core",
 ]
 
 [[package]]
@@ -3917,6 +3944,14 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fork-tree"
+version = "12.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "fork-tree"
 version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6736bef9fd175fafbb97495565456651c43ccac2ae550faee709e11534e3621"
@@ -3951,12 +3986,11 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9e5fcdb30bb83b2d97d7e718127230e0fbbad82b9c32dedf63971f08709def"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
- "frame-support-procedural 33.0.1",
+ "frame-support 28.0.0",
+ "frame-support-procedural 23.0.0",
  "frame-system",
  "linregress",
  "log",
@@ -3964,21 +3998,20 @@ dependencies = [
  "paste",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-runtime-interface 29.0.1",
- "sp-storage 22.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
+ "sp-storage 19.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43e7d09632b60f261e94854bdce91fd731a692b74b37e54e1a6e99a317a28d0"
+version = "32.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -3988,7 +4021,8 @@ dependencies = [
  "cumulus-client-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-storage-access-test-runtime",
+ "frame-support 28.0.0",
  "frame-system",
  "gethostname",
  "handlebars",
@@ -4000,35 +4034,37 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "rand_pcg",
- "sc-block-builder 0.44.0",
- "sc-chain-spec 42.0.0",
- "sc-cli 0.51.0",
- "sc-client-api 39.0.0",
- "sc-client-db 0.46.0",
- "sc-executor 0.42.0",
+ "sc-block-builder 0.33.0",
+ "sc-chain-spec 28.0.0",
+ "sc-cli 0.36.0",
+ "sc-client-api 28.0.0",
+ "sc-client-db 0.35.0",
+ "sc-executor 0.32.0",
+ "sc-executor-common 0.29.0",
+ "sc-executor-wasmtime 0.29.0",
  "sc-runtime-utilities",
- "sc-service 0.50.0",
- "sc-sysinfo 42.0.0",
+ "sc-service 0.35.0",
+ "sc-sysinfo 27.0.0",
  "serde",
  "serde_json",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-database",
- "sp-externalities 0.30.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-storage 22.0.0",
- "sp-timestamp 36.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
- "sp-wasm-interface",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-storage 19.0.0",
+ "sp-timestamp 26.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "sp-wasm-interface 20.0.0",
  "subxt",
  "subxt-signer",
  "thiserror 1.0.69",
@@ -4037,23 +4073,22 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6027a409bac4fe95b4d107f965fcdbc252fc89d884a360d076b3070b6128c094"
+checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
 dependencies = [
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
  "scale-type-resolver",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "16.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9ebdd91dfac51469c51f46d9d946f094be5dd4e7b1041f132ca1b40910f900"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4063,38 +4098,37 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067296b33b050f1ea93ef4885589d9cfe1f4d948c77c050592b883756c733ada"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
  "sp-npos-elections",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc32bb3f500bb1b4661ad73bc270890178f067af38ed7e4ab2c85d03b18b0f8"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "aquamarine",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-tracing",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
@@ -4102,18 +4136,6 @@ name = "frame-metadata"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cf1549fba25a6fcac22785b61698317d958e96cac72a59102ea45b9ae64692"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
- "serde",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701bac17e9b55e0f95067c428ebcb46496587f08e8cf4ccc0fe5903bea10dbb8"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -4134,20 +4156,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata-hash-extension"
-version = "0.8.0"
+name = "frame-metadata"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cb18dcd3517d3b994f2820749fe4a9e42c2a057a8c52b30bf21b00d5d6f2b9"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
  "docify",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -4163,7 +4196,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-io 34.0.0",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
@@ -4171,6 +4204,61 @@ dependencies = [
  "substrate-rpc-client",
  "tokio",
  "tokio-retry",
+]
+
+[[package]]
+name = "frame-storage-access-test-runtime"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "cumulus-pallet-parachain-system",
+ "parity-scale-codec",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
+ "substrate-wasm-builder",
+]
+
+[[package]]
+name = "frame-support"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "aquamarine",
+ "array-bytes 6.2.3",
+ "binary-merkle-tree",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata 23.0.0",
+ "frame-support-procedural 23.0.0",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-metadata-ir 0.6.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-tracing 16.0.0",
+ "sp-trie 29.0.0",
+ "sp-weights 27.0.0",
+ "tt-call",
 ]
 
 [[package]]
@@ -4197,10 +4285,10 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api 30.0.0",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
  "sp-core 32.0.0",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
+ "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-genesis-builder 0.11.0",
  "sp-inherents 30.0.0",
  "sp-io 34.0.0",
@@ -4208,53 +4296,31 @@ dependencies = [
  "sp-runtime 35.0.0",
  "sp-staking 30.0.0",
  "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
- "sp-weights",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 17.1.0",
+ "sp-weights 31.1.0",
  "static_assertions",
  "tt-call",
 ]
 
 [[package]]
-name = "frame-support"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c7c272704856cc88a86aef689a778050e59f89d7ec1e4ffb3a9e8e04e6b10"
+name = "frame-support-procedural"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "aquamarine",
- "array-bytes 6.2.3",
- "binary-merkle-tree",
- "bitflags 1.3.2",
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse",
  "docify",
- "environmental",
- "frame-metadata 20.0.0",
- "frame-support-procedural 33.0.1",
- "impl-trait-for-tuples",
- "k256",
- "log",
+ "expander",
+ "frame-support-procedural-tools 10.0.0",
+ "itertools 0.11.0",
  "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "sp-api 36.0.1",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-metadata-ir 0.10.0",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
- "sp-state-machine 0.45.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 39.1.0",
- "sp-weights",
- "tt-call",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4273,28 +4339,19 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 2.0.100",
 ]
 
 [[package]]
-name = "frame-support-procedural"
-version = "33.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb3c16c8fe1b4edc6df122212b50f776dfce31a94fa63305100841ba4eb7c93"
+name = "frame-support-procedural-tools"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
- "docify",
- "expander",
- "frame-support-procedural-tools 13.0.1",
- "itertools 0.11.0",
- "macro_magic",
- "proc-macro-warning",
+ "frame-support-procedural-tools-derive 11.0.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing",
  "syn 2.0.100",
 ]
 
@@ -4304,7 +4361,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
@@ -4312,13 +4369,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-support-procedural-tools"
-version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a088fd6fda5f53ff0c17fc7551ce8bd0ead14ba742228443c8196296a7369b"
+name = "frame-support-procedural-tools-derive"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4337,48 +4391,56 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc20d95c35bad22eb8b8d7ef91197a439483458237b176e621d9210f2fbff15"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-version 39.0.0",
- "sp-weights",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcf84c561e598ef31078af449398d87211867611ebc7068ba1364fba4c7e653"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244a5015742d349a814bc7f2aa999a9ec47924374a22672cfc3043a1eb87295f"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "parity-scale-codec",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
+]
+
+[[package]]
+name = "frame-try-runtime"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "frame-support 28.0.0",
+ "parity-scale-codec",
+ "sp-api 26.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -4391,19 +4453,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-api 30.0.0",
  "sp-runtime 35.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "frame-try-runtime"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac619a778035be86fc70ac58db9ae3d5d44107dac81ddcaa2f9e8744a0c71eb1"
-dependencies = [
- "frame-support 40.1.0",
- "parity-scale-codec",
- "sp-api 36.0.1",
- "sp-runtime 41.1.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4864,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -5626,7 +5676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -5677,41 +5727,41 @@ dependencies = [
  "polkadot-cli",
  "polkadot-primitives",
  "sc-basic-authorship",
- "sc-chain-spec 42.0.0",
- "sc-cli 0.51.0",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-chain-spec 28.0.0",
+ "sc-cli 0.36.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-aura",
  "sc-consensus-grandpa",
  "sc-consensus-manual-seal",
- "sc-executor 0.42.0",
- "sc-network 0.49.1",
- "sc-network-sync 0.48.0",
+ "sc-executor 0.32.0",
+ "sc-network 0.34.0",
+ "sc-network-sync 0.33.0",
  "sc-offchain",
- "sc-rpc 44.0.0",
- "sc-service 0.50.0",
- "sc-sysinfo 42.0.0",
- "sc-telemetry 28.1.0",
- "sc-tracing 39.0.0",
- "sc-transaction-pool 39.0.0",
- "sc-transaction-pool-api 39.0.0",
+ "sc-rpc 29.0.0",
+ "sc-service 0.35.0",
+ "sc-sysinfo 27.0.0",
+ "sc-telemetry 15.0.0",
+ "sc-tracing 28.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
  "serde",
  "serde_json",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-timestamp 36.0.0",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-timestamp 26.0.0",
  "staging-xcm",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.0",
  "try-runtime-cli",
  "wasmtime",
 ]
@@ -5723,11 +5773,11 @@ dependencies = [
  "deranged",
  "frame-benchmarking",
  "frame-executive",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "log",
  "pallet-assets",
  "pallet-aura",
@@ -5744,19 +5794,19 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime-common",
  "scale-info",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
  "substrate-wasm-builder",
 ]
 
@@ -5777,11 +5827,11 @@ dependencies = [
  "deranged",
  "frame-benchmarking",
  "frame-executive",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "hex-literal",
  "log",
  "pallet-assets",
@@ -5805,18 +5855,18 @@ dependencies = [
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-consensus-aura 0.42.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-std",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7510,7 +7560,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -7701,6 +7751,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-db"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6da20dba965bd218a14c3b335b90d3e07c09ede190c7c19b50deb23d418a322"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7765,38 +7825,36 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f6ea973b62de0b709281d596c5a54a5a89de7bb6d746e310a72f727af648ca"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
+ "sc-client-api 28.0.0",
  "sc-offchain",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
  "sp-consensus-beefy",
- "sp-core 36.1.0",
+ "sp-core 28.0.0",
  "sp-mmr-primitives",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff44bf4c30579dd6d4a536a28e767f3471ec3e3ecf0b5cb32e0e5b50cf9058e"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
  "serde",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
  "sp-mmr-primitives",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -8189,6 +8247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8413,126 +8480,121 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e063e39ad8ecd3c2b00c963f50cdf79e614c819a01e1c1ce9993287075b1b4d9"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e66408a38dcc61847fb287320600c75f7db21d3ca6a7e746a1153f1ced07701"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080d8f7ea66322bdb98ce467c47354e44d7f8f847fdeae921083ad792199b449"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-benchmarking",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "serde",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e7b226dac42400ed2bac82ecdb672413f805c7b48e481875c3ecb7f517bfcf"
+version = "29.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "ethereum-standards",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
+ "pallet-revive",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afcad52b78910d4acb9b260758f69d6167c2e5e03040bd87f42fa2e182f9bad"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
- "sp-consensus-aura 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cefc0e56c81e8140372ef6275ccd87e00e63d933c92e926fe0bc8de931b80e"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
+ "sp-application-crypto 30.0.0",
  "sp-authority-discovery",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08ec7786d0232e2f92f36e9e20c7414f3b4d763a35569c0b9c32ed90ed62c50"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c78d5bb4aa708189740d5be25ed6797e445972b5146f55d5e2111a2a3dc9560"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
@@ -8540,61 +8602,58 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
- "sp-consensus-babe 0.42.1",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "39.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2ba7f7b44bd74029bbd08cecf955ca38f5cdc9661ef00fbd2588d62995f37e"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "aquamarine",
  "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-tracing",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "41.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd7bf033312c976e0c044a80b4cd8b88471d7371baae6fea67b3f42eba288b"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "41.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a6b7d41ab2f2cd0b41baa2941ef9b9324ad26e5d0e5acc8e23a2b9482c5843"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
@@ -8603,21 +8662,20 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0d3f43f15e1b441146eab72196c3cea267e37a633ecaf535b69054eff72b"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-beefy",
@@ -8626,78 +8684,74 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
  "sp-consensus-beefy",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f80068c7a78879a529fd5548b0bddd4e053106484087dc16cbd81db6b4e251"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f227cf4ee9025e9387547e37300bd00c1c19e786eb23276268af7dc710915ce3"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d077d3b33d4f4f8fb92197def4498e2f18a3ff476f65bb7557a766406c5feb1a"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa9a18a85915578e3e41fd4aea50a9db64fb57c97296e6a311373f68e40face"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
@@ -8706,217 +8760,204 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f813d7dec4ed85cb95bf3b05315fd8ce14b38746fd11cce794cec238cf9fc16d"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1827efa28acb4e5d26d0840c2909b1770ea8cc89028f3be4a7f6114a589b1c8"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f9e8d2e1a11aa809779748c073ec9e6d44807fbdae7787edbbbbff673ee015"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "39.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e20002d915da6fa29b2b1e932c7610e963e81de11e32b0d9c24e13de7798f8"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
- "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
  "sp-npos-elections",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5db80ea1d9cab28608ad2747981640a82de9d2f8c3d096664ff9e557a42a7c1"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "41.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf5efc33f6a2eeb167c4b8f065da0417bf76898982f413aca07fae7e1571efc"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
  "sp-npos-elections",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61735a183468e51aec3a8bfda874acab4f07026a89dec8841394a5f45010ebb7"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7248e836db9e07b2262b83bd638e0070f5d2357d63519920317473ad90d3fac2"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c97dbd01716801ca490a21a4b525f5149b7c2350f3e56b1c6332bb2d471bdb"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "39.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadfed668f67c5c483a40cd24ee7d0453bb53eb41aa393898f471e837724df48"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9305e70776c08ac9a3cdc3885b23306c466b16e75611efeea601fb92cbf250"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a0040f827f90164ea0db81478967c6118c72f9cf7b667eec82d4f88ba8b291"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8925,86 +8966,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-membership"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca06af7edcaa916effec49edc0ebbc41ca7a7c00c9824eafbe729a36a73fb0d"
-dependencies = [
- "frame-benchmarking",
- "frame-support 40.1.0",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
-]
-
-[[package]]
 name = "pallet-message-queue"
-version = "43.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ef2434f1354b0db1f5ee9419e627e726519dc617272daa626aeb0a64c3b57b"
+version = "31.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "environmental",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "pallet-meta-tx"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7ac6c05036e97818ae77ec75020ec509b5b976161a5b10f7197b854868dd40"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-std",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-migrations"
-version = "10.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290a3db17ac6eb9bc965a37eb689b35403f47930b4097626b7b8d07f651caf33"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2a5b9cfceb0073d7282733a38473b2b8ba4d93d596c2aa23a2b73900515f11"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9015,9 +9035,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1dbd8f9e06763b6e7b918d56fa780d8301e908316e8091a38dec764218e626"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9027,9 +9046,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b386745d5656d2f4ea86a7fd22adb7cda2e28c3bed096eb329634b3ee8037d79"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9038,32 +9056,30 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "38.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74b7d33fa2b626d3b682967eb65577589e585475a5b43383fc6851ae5852d82"
+version = "25.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
- "sp-tracing",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec00fd90b8572eb87d1400460d3de3208502f79545ae8fa999c7d0971d0019e"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-bags-list",
  "pallet-delegated-staking",
@@ -9071,47 +9087,44 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
- "sp-runtime-interface 29.0.1",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9b92dab01524bdc25e304f39b29e6b88c0c5e3280527870b001efbdec03615"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620a4bec35376b1262d7d086a53ac200960b15c531704cf241ed21d913a01558"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42ff0f4b9e7b7fb21a2030177d48548b0f2a7799011c179945504103235a648"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-babe",
@@ -9123,50 +9136,47 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-parameters"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64da32561c7fee79be35bfb39bc95199dddccf728b7daa9c2d89fad4b0209d29"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becb813ca45bef02a52869c3c865f84be01d6b92d0b6c411c3e219e95907dbbd"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f84c01677715acc9590b393623393f722c0df459b8dcd9465ae0ac46bb904d0"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9175,70 +9185,62 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e86c56283de489f9600e9d22cc671def37848ab82962db804ba1ef845a824f"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02eeb358622a13124326b57fc26fbcd2258f7f123cee704c6537c6f2d0c83546"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-benchmarking",
- "frame-support 40.1.0",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3d59e9e5b9f6c3c5b7db8bbec7fc937fdc8212b9393647aea7f91413264762"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-arithmetic 23.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-revive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff67ac7b1053411a2bd2f5438cc0fa0c58757ec0c51efa551f1cfcd9ebc7ee3"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.19",
  "environmental",
- "ethabi-decode",
+ "ethereum-standards",
  "ethereum-types",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "hex-literal",
  "humantime-serde",
@@ -9256,44 +9258,41 @@ dependencies = [
  "polkavm 0.21.0",
  "polkavm-common 0.21.0",
  "rand 0.8.5",
+ "rand_pcg",
  "ripemd",
  "rlp 0.6.1",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-arithmetic",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-babe 0.42.1",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "staging-xcm",
- "staging-xcm-builder",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "substrate-bn",
  "subxt-signer",
 ]
 
 [[package]]
 name = "pallet-revive-fixtures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1df19ca809f036d6ddf1632039e9db312f92dbe8f9390e6722ad808cd95377"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "pallet-revive-uapi",
  "polkavm-linker 0.21.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
  "toml 0.8.20",
 ]
 
 [[package]]
 name = "pallet-revive-proc-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c2dc2fc6961da23fefc54689ce81a8e006f6988bc465dcc9ab9db905d31766"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9302,9 +9301,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive-uapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb8f45102c6279f59f55e0051fc6c26b996619d7842800dfaf3a2583459a1c7"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -9315,103 +9313,96 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96456f941dc194636e81851e77666fc39638a36ce39952cb51e4c1027b6b7b0"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7de58764e1499f570f180c81ba1fff24a1a3d5c9bfdcf76b6a384a985dcdd39"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35361f753986d6fe6654b3e5d283700c4f0bb082221c6aaf299912a29679c880"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
- "sp-state-machine 0.45.0",
- "sp-trie 39.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4605d946187282ead36c12acb64f75d8c36beacc1b866002491c7d56e63eb2af"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5af40e2fabefa91aeb8a872170242c40056aaf7658c8ac7e6f0b4bfc75263b5"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
- "sp-arithmetic",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-arithmetic 23.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe698a05666fabe5a5f60da69ddef674262fe84bd0f93f03ddacfba7fe4c361"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-authorship",
@@ -9420,161 +9411,185 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 40.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+]
+
+[[package]]
+name = "pallet-staking-async-ah-client"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "frame-support 28.0.0",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-staking-async-rc-client",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+]
+
+[[package]]
+name = "pallet-staking-async-rc-client"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "frame-support 28.0.0",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "22.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b982dbfe9fbc548dc7f9a3078214989ed58cabf521a8313ae1767d6b4b53b9b"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "log",
- "sp-arithmetic",
+ "sp-arithmetic 23.0.0",
 ]
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1334393e1712a68fc114843bc66c0ec7d57d3f0b0de5a1f10f2355b8b736db2"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
- "sp-api 36.0.1",
- "sp-staking 38.0.0",
+ "sp-api 26.0.0",
+ "sp-staking 26.0.0",
 ]
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "44.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7954fe634d7fb20902d04815aa2fb87e4d47736158e83cefd6abd6ea9938bab1"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcb93e724a2acc7041d1e368895bc3ce272b6db8338a079037395cd5e6a97db"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf2c41020fe6b676345a2f4e224faf128ba26dfc5d4da7938d1a91049dc3203"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-storage 22.0.0",
- "sp-timestamp 36.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-storage 19.0.0",
+ "sp-timestamp 26.0.0",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884613a538e24d02d1848107e4ad66c569a28d227545e3a267ce165e30a7f468"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ebd61b64848e39e5615832c964dc10b63bcebff26a9ec1cb867b4087240a03"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d27cee9496b7e9d6ad6ae4ff6daa71d47f98fd2593fd16e79537f5993c1447"
+version = "30.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "jsonrpsee 0.24.9",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-rpc 34.0.0",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-rpc 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bd3329d44b44623b7615cc069b292f2a1fe5c0f4a6625c36cc906f2a43fcc1"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 36.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-api 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd2d341f5df906bcfb7ff50e9abb97769786ba0ed36bfef10d88c9df6a06342"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
@@ -9582,63 +9597,58 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a321f0aec416f3369a71a2bb0ad41f415823ff140fd22b1a3b724dfa6256f7"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-verify-signature"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96278292b47088c38ca911f1e8ad32171d1e42398d26014e57e7fbed3d2375a"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e1e6521dfdd7bc9c5ab16489e85e30e94f9ccb7a20e3caa073fb17c9e73f7"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb90b146d30677b8a343dc9f6fce011511f8db92fabe6b18ba27d8888f8d95e"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9647,21 +9657,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "19.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca27d506282f4c9cd2cac6fb0d199edd89d366635f04801319e7145912547a68"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9671,17 +9680,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc762e28929d9d3a0d65e1e13d79fb258c423a80bb3ab57ff0b2fc8d8cfb04d"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9689,13 +9697,12 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68844f03979cb0c8b208306047f3b1134b59c74c1fdc9b7f2d8a591ba69b956"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "log",
  "pallet-asset-tx-payment",
@@ -9708,10 +9715,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "sp-consensus-aura 0.42.0",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -9753,9 +9760,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -9770,9 +9777,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -10043,9 +10050,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0cb45ad4546e8681b6221997dc63fb2f23ecaed10caacbeb011f3510465632"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10062,9 +10068,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0616a7d5237331efafdac3c072da4edcf1c0112fd4dc3adc7f41815892e7f17"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10078,9 +10083,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d9a5b1bb272a5bc32620b815b551f8f1786518f14014768e67d049af536e4d"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "fatality",
  "futures",
@@ -10092,19 +10096,18 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-network 0.49.1",
+ "sc-network 0.34.0",
  "schnellru",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d90d2db188a3d373bd47ec0b9f5988a74bea127a1aeaf6ac87839d4b61ff75f"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10117,7 +10120,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-network 0.49.1",
+ "sc-network 0.34.0",
  "schnellru",
  "thiserror 1.0.69",
  "tokio",
@@ -10136,9 +10139,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cd8e825bcc84ec657862a0f1bd13dd5feab64b5f07f447359a391d9fcc14d6"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10147,23 +10149,22 @@ dependencies = [
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-service",
- "sc-cli 0.51.0",
- "sc-service 0.50.0",
+ "sc-cli 0.36.0",
+ "sc-service 0.35.0",
  "sc-storage-monitor",
- "sc-sysinfo 42.0.0",
- "sc-tracing 39.0.0",
- "sp-core 36.1.0",
- "sp-keyring 41.0.0",
- "sp-runtime 41.1.0",
+ "sc-sysinfo 27.0.0",
+ "sc-tracing 28.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-runtime 31.0.1",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b4d7a7ace3faead952e15c449d7d45cbf53901c06e1c7eeaaa8b23a49b4280"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10175,9 +10176,9 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "schnellru",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
  "tokio-util",
  "tracing-gum",
@@ -10185,21 +10186,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "17.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7c519ee804fd08d7464871bd2fe164e8f0683501ea59d2a10f5ef214dacb3b"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec75c5ebcf05c04f039db64f0ccdb1a4e1ed99d6019a43fefc4a07526c6b02f9"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "fatality",
  "futures",
@@ -10211,33 +10210,31 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sc-network 0.49.1",
- "sp-application-crypto 40.1.0",
- "sp-keystore 0.42.0",
+ "sc-network 0.34.0",
+ "sp-application-crypto 30.0.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ca21ac0a13df6cc98ac44ae16e1bd270979d75094671db110a80c5e8ca1c47"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
- "sp-core 36.1.0",
- "sp-trie 39.1.0",
+ "sp-core 28.0.0",
+ "sp-trie 29.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e75c05c6a9048e3a021bfa65f88cbca412af123779004dab713311dcccecc9"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10247,19 +10244,18 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "sc-network 0.49.1",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-keystore 0.42.0",
+ "sc-network 0.34.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-keystore 0.34.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b4f4325b68a2b8478fe527f7b964ea227f36a4e543e705821c77a98a6f23f6"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10273,17 +10269,16 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "sc-network 0.49.1",
- "sp-consensus 0.42.0",
+ "sc-network 0.34.0",
+ "sp-consensus 0.32.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcecb45c4ad870623b11188d32c4ebf18366f0f7ec7ceb54475b2732048df5f3"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10293,16 +10288,15 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "schnellru",
- "sp-core 36.1.0",
+ "sp-core 28.0.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675753ce0f12f89a1c656b35bfd4a1ced2f6942bc71b323fab96dc5a3f7ae3a0"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10320,22 +10314,21 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sc-keystore 35.0.0",
+ "sc-keystore 25.0.0",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 40.1.0",
- "sp-consensus 0.42.0",
- "sp-consensus-slots 0.42.1",
- "sp-runtime 41.1.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555cf6e981c00516136cf78574108d623076f44af7991c05fbb46adb0866e35a"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
@@ -10351,16 +10344,15 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "sc-keystore 35.0.0",
- "sp-consensus 0.42.0",
+ "sc-keystore 25.0.0",
+ "sp-consensus 0.32.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c90e433cb19b36206f367e995b024769b7fbf415fb5c972f72695e8264cc73d"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "futures",
@@ -10371,16 +10363,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-consensus 0.42.0",
+ "sp-consensus 0.32.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0251fff91cfc08fa4d17d7a5b8a23a5a1d6650e7301c6b4e15bf43ce8070b4ce"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10393,22 +10384,21 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore 0.42.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92821ffff303af8b9b7d6f7f2938cf6dc018f3d82304cf8681dc47c96bf8a26"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore 0.42.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
  "wasm-timer",
@@ -10416,9 +10406,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69ddbef474fed56f143d456d8f67cfd40d88e769f665c809900f07817948d66"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
@@ -10432,31 +10421,29 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sp-application-crypto 40.1.0",
- "sp-keystore 0.42.0",
+ "sp-application-crypto 30.0.0",
+ "sp-keystore 0.34.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeff222b5b70bab8f3c2b7c2226d405e53ef42d4602f68cd0d214407f662420"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "sc-client-api 39.0.0",
+ "sc-client-api 28.0.0",
  "sc-consensus-babe",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3cdc2aeb6655ab6ef1fd694c5805ec8d008574b3a53941b124a609c3ce63e61"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10471,9 +10458,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09700ab6690b621f9f27004c7fcd917e2a6f8ac609d15fd1888c51ff98b5d92e"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "fatality",
  "futures",
@@ -10482,7 +10468,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sc-keystore 35.0.0",
+ "sc-keystore 25.0.0",
  "schnellru",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -10490,9 +10476,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1416dd3b87d47fe0f512a34aa89903636bd0d60d10ae1e9054a810419879e"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
@@ -10500,17 +10485,16 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "sp-blockchain 39.0.0",
- "sp-inherents 36.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-inherents 26.0.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a8b186650cfc16214f3740d2ea50a5df47995d850461d737179971318febd5"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "fatality",
  "futures",
@@ -10523,9 +10507,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc73376fe9904f949feeed67cc9ae17a92ff17f356734d44c5bcca0136ca178a"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10541,9 +10524,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a4334d9d9f89b1c13b8ff57610ba8153197838663415c4cea7553fc03ff18c"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -10558,9 +10540,9 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-tracing 39.0.0",
+ "sc-tracing 28.0.0",
  "slotmap",
- "sp-core 36.1.0",
+ "sp-core 28.0.0",
  "strum 0.26.3",
  "tempfile",
  "thiserror 1.0.69",
@@ -10570,23 +10552,21 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa710b7ac4e1125271dd8b618f50598f99f1ec46ab729a7e220813f8573c5a2f"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore 0.42.0",
+ "sp-keystore 0.34.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c737870687d141d04030ca72fbaa40aa69dde3084777e6e438f821180588490e"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10596,24 +10576,23 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sc-executor 0.42.0",
- "sc-executor-common 0.38.0",
- "sc-executor-wasmtime 0.38.0",
+ "sc-executor 0.32.0",
+ "sc-executor-common 0.29.0",
+ "sc-executor-wasmtime 0.29.0",
  "seccompiler",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-externalities 0.30.0",
- "sp-io 40.0.1",
- "sp-tracing",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-io 30.0.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066b99e3c9e4dc83bbb5386c4bd28af5ec34180228f8989af27ac9b545ea0268"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10621,15 +10600,14 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "schnellru",
- "sp-consensus-babe 0.42.1",
+ "sp-consensus-babe 0.32.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf32dc99967ac877ee66e1c2daa786c67d4ef6cb4509e5a14f3761872796a7e7"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10637,17 +10615,16 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "sc-cli 0.51.0",
- "sc-service 0.50.0",
- "sc-tracing 39.0.0",
- "substrate-prometheus-endpoint",
+ "sc-cli 0.36.0",
+ "sc-service 0.35.0",
+ "sc-tracing 28.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
 ]
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3821cb26256e3ee8af41f156198b075c030d4d066fcfea237b5596a154a1bf8"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10661,9 +10638,9 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "sc-authority-discovery",
- "sc-network 0.49.1",
+ "sc-network 0.34.0",
  "sc-network-types",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
  "strum 0.26.3",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -10671,9 +10648,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758d25d7532f3a952f4a52079e580e4fc45a9825ac926cbfac6128d8236b8260"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10682,23 +10658,22 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sc-keystore 35.0.0",
+ "sc-keystore 25.0.0",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 40.1.0",
- "sp-consensus-babe 0.42.1",
- "sp-consensus-slots 0.42.1",
- "sp-keystore 0.42.0",
- "sp-maybe-compressed-blob",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-keystore 0.34.0",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e286a2e0db2a9f069b9f726caf7fd369e0722b8215d77b5f3aaa52263e6218"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -10706,9 +10681,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e4a49a9be59cdd68922591e706bd6093d5175277b8417b37982025887a7af"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "derive_more 0.99.19",
@@ -10719,25 +10693,24 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "polkadot-statement-table",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
  "sc-network-types",
- "sc-transaction-pool-api 39.0.0",
+ "sc-transaction-pool-api 28.0.0",
  "smallvec",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
  "sp-authority-discovery",
- "sp-blockchain 39.0.0",
- "sp-consensus-babe 0.42.1",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sp-blockchain 28.0.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70468d8e749ce00f53660f984735ba8a1bc9a67e0cab3331fbc54e2e48832e03"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "fatality",
  "futures",
@@ -10756,20 +10729,18 @@ dependencies = [
  "polkadot-primitives",
  "prioritized-metered-channel",
  "rand 0.8.5",
- "sc-client-api 39.0.0",
  "schnellru",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-overseer"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259500517ee35d71f64f1d03dfc62684105fe3568372f6ff08a20349db250c38"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
@@ -10780,17 +10751,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
- "sc-client-api 39.0.0",
- "sp-core 36.1.0",
+ "sc-client-api 28.0.0",
+ "sp-core 28.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "16.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72943c0948c686b47bacb1a03e59baff63bfba2e16e208d77f0f8615827f8564"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.19",
@@ -10798,18 +10768,18 @@ dependencies = [
  "polkadot-core-primitives",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "18.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46b3d45e295d975a9be6128212b29e0efd05f26cdde4a45115424a1f6bad0dd"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
+ "bounded-collections",
  "hex-literal",
  "log",
  "parity-scale-codec",
@@ -10817,65 +10787,63 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
  "sp-authority-discovery",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
- "sp-std",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7421c71193e9f72fa5a27104ff1a8b9fb99d8e9d7880e862e1bc3583d5620795"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "jsonrpsee 0.24.9",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
  "sc-consensus-babe",
  "sc-consensus-babe-rpc",
  "sc-consensus-beefy",
  "sc-consensus-beefy-rpc",
  "sc-consensus-grandpa",
  "sc-consensus-grandpa-rpc",
- "sc-rpc 44.0.0",
+ "sc-rpc 29.0.0",
  "sc-sync-state-rpc",
- "sc-transaction-pool-api 39.0.0",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-babe 0.42.1",
+ "sc-transaction-pool-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-babe 0.32.0",
  "sp-consensus-beefy",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "19.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccd922c8032004e38c1a6cab86f304949d04e61e270c982b06a02132d53bf58"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
@@ -10902,15 +10870,15 @@ dependencies = [
  "scale-info",
  "serde",
  "slot-range-helper",
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
  "sp-npos-elections",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10919,27 +10887,26 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b4a652ead58e7697a773d819f842d821b7feabdb5e5252d4af0cc0c1ad260"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-tracing",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "19.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a4c580cf509b6b7d4f2b556e31da04e528c69acfaeec28d5ac7f02b4dc0fa9"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-election-provider-support",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
@@ -10962,72 +10929,61 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
- "sp-std",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
 ]
 
 [[package]]
-name = "polkadot-sdk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb819108697967452fa6d8d96ab4c0d48cbaa423b3156499dcb24f1cf95d6775"
-dependencies = [
- "sp-crypto-hashing",
-]
-
-[[package]]
 name = "polkadot-sdk-frame"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386c622773c64ba462fea05debe20d71b0caf5d273a6cdb8277a1ca853adfd1c"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-executive",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-arithmetic",
- "sp-block-builder 36.0.0",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aa9046b966828663c4e42ba61e29a14456e02d15c513ac14936348a45f21f2"
+version = "7.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11085,49 +11041,49 @@ dependencies = [
  "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-babe",
  "sc-consensus-beefy",
  "sc-consensus-grandpa",
  "sc-consensus-slots",
- "sc-executor 0.42.0",
- "sc-keystore 35.0.0",
- "sc-network 0.49.1",
- "sc-network-sync 0.48.0",
+ "sc-executor 0.32.0",
+ "sc-keystore 25.0.0",
+ "sc-network 0.34.0",
+ "sc-network-sync 0.33.0",
  "sc-offchain",
- "sc-service 0.50.0",
+ "sc-service 0.35.0",
  "sc-sync-state-rpc",
- "sc-sysinfo 42.0.0",
- "sc-telemetry 28.1.0",
- "sc-transaction-pool 39.0.0",
- "sc-transaction-pool-api 39.0.0",
+ "sc-sysinfo 27.0.0",
+ "sc-telemetry 15.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
  "serde",
  "serde_json",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
  "sp-authority-discovery",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-babe 0.42.1",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-babe 0.32.0",
  "sp-consensus-beefy",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
  "sp-mmr-primitives",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-timestamp 36.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
- "sp-weights",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-timestamp 26.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
+ "sp-weights 27.0.0",
  "staging-xcm",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
  "tracing-gum",
  "westend-runtime",
@@ -11136,33 +11092,28 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d7f4a8d4ecb61cffa9095b3ceb1aa37e47b087271afd1ea23b8642e99872ab"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "arrayvec 0.7.6",
  "bitvec",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.9.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore 0.42.0",
- "sp-staking 38.0.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6d47fecf55aba37980922e8eff6d13667ca20ac1969637c220770a033d81f1"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11184,19 +11135,6 @@ dependencies = [
 
 [[package]]
 name = "polkavm"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd044ab1d3b11567ab6b98ca71259a992b4034220d5972988a0e96518e5d343d"
-dependencies = [
- "libc",
- "log",
- "polkavm-assembler 0.18.0",
- "polkavm-common 0.18.0",
- "polkavm-linux-raw 0.18.0",
-]
-
-[[package]]
-name = "polkavm"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd34e2f74206fff33482ae1718e275f11365ef8c4de7f0e69217f8845303867"
@@ -11206,6 +11144,19 @@ dependencies = [
  "polkavm-assembler 0.21.0",
  "polkavm-common 0.21.0",
  "polkavm-linux-raw 0.21.0",
+]
+
+[[package]]
+name = "polkavm"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a01db119bb3a86572c0641ba6e7c9786fbd2ac89c25b43b688c4e353787526"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler 0.24.0",
+ "polkavm-common 0.24.0",
+ "polkavm-linux-raw 0.24.0",
 ]
 
 [[package]]
@@ -11219,18 +11170,18 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad38dc420bfed79e6f731471c973ce5ff5e47ab403e63cf40358fef8a6368f"
+checksum = "f512bc80cb10439391a7c13a9eb2d37cf66b7305e7df0a06d662eff4f5b07625"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f512bc80cb10439391a7c13a9eb2d37cf66b7305e7df0a06d662eff4f5b07625"
+checksum = "eea6105f3f344abe0bf0151d67b3de6f5d24353f2393355ecf3f5f6e06d7fd0b"
 dependencies = [
  "log",
 ]
@@ -11246,16 +11197,6 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
-dependencies = [
- "log",
- "polkavm-assembler 0.18.0",
-]
-
-[[package]]
-name = "polkavm-common"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c16b809cfd398f861261c045a8745e6c78b71ea7e0d3ef6f7cc553eb27bc17e"
@@ -11263,6 +11204,16 @@ dependencies = [
  "blake3",
  "log",
  "polkavm-assembler 0.21.0",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed9e5af472f729fcf3b3c1cf17508ddbb3505259dd6e2ee0fb5a29e105d22"
+dependencies = [
+ "log",
+ "polkavm-assembler 0.24.0",
 ]
 
 [[package]]
@@ -11276,20 +11227,20 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
-dependencies = [
- "polkavm-derive-impl-macro 0.18.0",
-]
-
-[[package]]
-name = "polkavm-derive"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47239245f87329541932c0d7fec750a66a75b13aa87dfe4fbfd637bab86ad387"
 dependencies = [
  "polkavm-derive-impl-macro 0.21.0",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176144f8661117ea95fa7cf868c9a62d6b143e8a2ebcb7582464c3faade8669a"
+dependencies = [
+ "polkavm-derive-impl-macro 0.24.0",
 ]
 
 [[package]]
@@ -11299,18 +11250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
  "polkavm-common 0.9.0",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
-dependencies = [
- "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -11329,22 +11268,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-derive-impl"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a21844afdfcc10c92b9ef288ccb926211af27478d1730fcd55e4aec710179d"
+dependencies = [
+ "polkavm-common 0.24.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "polkavm-derive-impl-macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "polkavm-derive-impl-macro"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
-dependencies = [
- "polkavm-derive-impl 0.18.1",
  "syn 2.0.100",
 ]
 
@@ -11359,19 +11300,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkavm-linker"
-version = "0.18.0"
+name = "polkavm-derive-impl-macro"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bfe793b094d9ea5c99b7c43ba46e277b0f8f48f4bbfdbabf8d3ebf701a4bd3"
+checksum = "ba0ef0f17ad81413ea1ca5b1b67553aedf5650c88269b673d3ba015c83bc2651"
 dependencies = [
- "dirs",
- "gimli 0.31.1",
- "hashbrown 0.14.5",
- "log",
- "object 0.36.7",
- "polkavm-common 0.18.0",
- "regalloc2 0.9.3",
- "rustc-demangle",
+ "polkavm-derive-impl 0.24.0",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -11391,6 +11326,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-linker"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c95a521a1331024ebe5823ffdfba9ea6df40b934b0804049d5171887579806"
+dependencies = [
+ "dirs",
+ "gimli 0.31.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.7",
+ "polkavm-common 0.24.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "polkavm-linux-raw"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11398,15 +11349,15 @@ checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eff02c070c70f31878a3d915e88a914ecf3e153741e2fb572dde28cce20fde"
-
-[[package]]
-name = "polkavm-linux-raw"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be6cd1d48c5e7814d287a3e12a339386a5dfa2f3ac72f932335f4cf56467f1b3"
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec0b13e26ec7234dba213ca17118c70c562809bdce0eefe84f92613d5c8da26"
 
 [[package]]
 name = "polling"
@@ -12060,7 +12011,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "serde",
 ]
 
 [[package]]
@@ -12071,6 +12021,7 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -12118,6 +12069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -12426,20 +12378,19 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbaa7cfad8e24ca76b48eb977527234c1e148b3184301ccb012427bcaefd474"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "hex-literal",
  "log",
  "pallet-asset-rate",
@@ -12496,26 +12447,26 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sp-api 36.0.1",
- "sp-arithmetic",
+ "sp-api 26.0.0",
+ "sp-arithmetic 23.0.0",
  "sp-authority-discovery",
- "sp-block-builder 36.0.0",
- "sp-consensus-babe 0.42.1",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-babe 0.32.0",
  "sp-consensus-beefy",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
  "sp-mmr-primitives",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -12525,17 +12476,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c295ecea37ee949577dba8dfef7beb3de5492bb88bbbec6b0dc327ff63ee85b0"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -13013,33 +12963,31 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "log",
+ "sp-core 28.0.0",
+ "sp-wasm-interface 20.0.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-allocator"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97e78771bbc491d4d601afbbf01f5718d6d724d0d971c8581cf5b4c62a9502f7"
 dependencies = [
  "log",
  "sp-core 32.0.0",
- "sp-wasm-interface",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sc-allocator"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c10a9966875fcbde028c73697c6d5faad5f5d24e94b3c949fb1d063c727381d"
-dependencies = [
- "log",
- "sp-core 36.1.0",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbf3f7d818fbb607fc6991b603964b2bfe68857cd3f722a87c511d04bb43682"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
@@ -13051,39 +12999,53 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.13.5",
  "rand 0.8.5",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
  "sc-network-types",
- "sp-api 36.0.1",
+ "sp-api 26.0.0",
  "sp-authority-discovery",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9132e1990352be9840c18186e4ce3e810dfc146728ced1ac6b2da4eb794a547"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "sc-block-builder 0.44.0",
+ "sc-block-builder 0.33.0",
  "sc-proposer-metrics",
- "sc-telemetry 28.1.0",
- "sc-transaction-pool-api 39.0.0",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sc-telemetry 15.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
+]
+
+[[package]]
+name = "sc-block-builder"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
@@ -13103,19 +13065,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-block-builder"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6622da4fe938fed2f4e0f127c92cee835dedc325fb4c2358c03912232beee24"
+name = "sc-chain-spec"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "array-bytes 6.2.3",
+ "docify",
+ "memmap2 0.9.5",
  "parity-scale-codec",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-trie 39.1.0",
+ "sc-chain-spec-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sc-client-api 28.0.0",
+ "sc-executor 0.32.0",
+ "sc-network 0.34.0",
+ "sc-telemetry 15.0.0",
+ "serde",
+ "serde_json",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-genesis-builder 0.8.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
@@ -13129,7 +13101,7 @@ dependencies = [
  "log",
  "memmap2 0.9.5",
  "parity-scale-codec",
- "sc-chain-spec-derive 11.0.0",
+ "sc-chain-spec-derive 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sc-client-api 32.0.0",
  "sc-executor 0.36.0",
  "sc-network 0.38.0",
@@ -13138,38 +13110,11 @@ dependencies = [
  "serde_json",
  "sp-blockchain 32.0.0",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-genesis-builder 0.11.0",
  "sp-io 34.0.0",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
-]
-
-[[package]]
-name = "sc-chain-spec"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ca4ca82a725cc03078839d823ed0f999507ffd0b9a3b24a5f21cf10f24e2e0"
-dependencies = [
- "array-bytes 6.2.3",
- "docify",
- "memmap2 0.9.5",
- "parity-scale-codec",
- "sc-chain-spec-derive 12.0.0",
- "sc-client-api 39.0.0",
- "sc-executor 0.42.0",
- "sc-network 0.49.1",
- "sc-telemetry 28.1.0",
- "serde",
- "serde_json",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-genesis-builder 0.17.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-tracing",
 ]
 
 [[package]]
@@ -13186,14 +13131,55 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "sc-cli"
+version = "0.36.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "array-bytes 6.2.3",
+ "chrono",
+ "clap",
+ "fdlimit",
+ "futures",
+ "itertools 0.11.0",
+ "libp2p-identity 0.2.10",
+ "log",
+ "names",
+ "parity-bip39",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "regex",
+ "rpassword",
+ "sc-client-api 28.0.0",
+ "sc-client-db 0.35.0",
+ "sc-keystore 25.0.0",
+ "sc-mixnet 0.4.0",
+ "sc-network 0.34.0",
+ "sc-service 0.35.0",
+ "sc-telemetry 15.0.0",
+ "sc-tracing 28.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-utils 14.0.0",
+ "serde",
+ "serde_json",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-panic-handler 13.0.0",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -13231,7 +13217,7 @@ dependencies = [
  "sp-core 32.0.0",
  "sp-keyring 35.0.0",
  "sp-keystore 0.38.0",
- "sp-panic-handler",
+ "sp-panic-handler 13.0.2",
  "sp-runtime 35.0.0",
  "sp-version 33.0.0",
  "thiserror 1.0.69",
@@ -13239,46 +13225,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-cli"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0f6424aacf055719cee01d59a1153aa8aed9739cff3beec0aea5675b13afe"
+name = "sc-client-api"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "array-bytes 6.2.3",
- "chrono",
- "clap",
- "fdlimit",
+ "fnv",
  "futures",
- "itertools 0.11.0",
- "libp2p-identity 0.2.10",
  "log",
- "names",
- "parity-bip39",
  "parity-scale-codec",
- "rand 0.8.5",
- "regex",
- "rpassword",
- "sc-client-api 39.0.0",
- "sc-client-db 0.46.0",
- "sc-keystore 35.0.0",
- "sc-mixnet 0.19.0",
- "sc-network 0.49.1",
- "sc-service 0.50.0",
- "sc-telemetry 28.1.0",
- "sc-tracing 39.0.0",
- "sc-transaction-pool 39.0.0",
- "sc-utils 18.0.1",
- "serde",
- "serde_json",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-keyring 41.0.0",
- "sp-keystore 0.42.0",
- "sp-panic-handler",
- "sp-runtime 41.1.0",
- "sp-version 39.0.0",
- "thiserror 1.0.69",
- "tokio",
+ "parking_lot 0.12.3",
+ "sc-executor 0.32.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-storage 19.0.0",
+ "sp-trie 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
 ]
 
 [[package]]
@@ -13299,41 +13268,42 @@ dependencies = [
  "sp-blockchain 32.0.0",
  "sp-consensus 0.36.0",
  "sp-core 32.0.0",
- "sp-database",
+ "sp-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.28.0",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
  "sp-statement-store 14.0.0",
  "sp-storage 21.0.0",
  "sp-trie 33.0.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
 ]
 
 [[package]]
-name = "sc-client-api"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace1a9f5b53e738a353079a5e5a41e55fa62887cc1d7491b97feca6847b4f88d"
+name = "sc-client-db"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "fnv",
- "futures",
+ "hash-db",
+ "kvdb",
+ "kvdb-memorydb",
+ "kvdb-rocksdb",
+ "linked-hash-map",
  "log",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-executor 0.42.0",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-database",
- "sp-externalities 0.30.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-storage 22.0.0",
- "sp-trie 39.1.0",
- "substrate-prometheus-endpoint",
+ "sc-client-api 28.0.0",
+ "sc-state-db 0.30.0",
+ "schnellru",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
+ "sysinfo",
 ]
 
 [[package]]
@@ -13354,40 +13324,36 @@ dependencies = [
  "sc-client-api 32.0.0",
  "sc-state-db 0.34.0",
  "schnellru",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
  "sp-blockchain 32.0.0",
  "sp-core 32.0.0",
- "sp-database",
+ "sp-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
  "sp-trie 33.0.0",
 ]
 
 [[package]]
-name = "sc-client-db"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dfc8b2f7156ced83fc9e52a610b580a54d2499e7674f8f629ea3a11e4c2d0e9"
+name = "sc-consensus"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "hash-db",
- "kvdb",
- "kvdb-memorydb",
- "kvdb-rocksdb",
- "linked-hash-map",
+ "async-trait",
+ "futures",
  "log",
- "parity-db",
- "parity-scale-codec",
+ "mockall 0.13.1",
  "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-state-db 0.38.0",
- "schnellru",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-database",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-trie 39.1.0",
+ "sc-client-api 28.0.0",
+ "sc-network-types",
+ "sc-utils 14.0.0",
+ "serde",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "substrate-prometheus-endpoint 0.17.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -13412,72 +13378,46 @@ dependencies = [
  "sp-core 32.0.0",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
- "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sc-consensus"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15adbad0ca8f3312ff19ec97ef75bce5809518ff4725121e7885d42bb8de5fea"
-dependencies = [
- "async-trait",
- "futures",
- "log",
- "mockall 0.13.1",
- "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-network-types",
- "sc-utils 18.0.1",
- "serde",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5863f442a228f9cee8c5e75a9abda97f3b9a2dd8221b0e0a9201319fc4b9313d"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "parity-scale-codec",
- "sc-block-builder 0.44.0",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-block-builder 0.33.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-slots",
- "sc-telemetry 28.1.0",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sc-telemetry 15.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc081187456c1d7b638b8c2882a0073da7cb30eccdd2d7bb1d63171b5e40b4a"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
- "fork-tree",
+ "fork-tree 12.0.0",
  "futures",
  "log",
  "num-bigint",
@@ -13485,56 +13425,54 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-epochs",
  "sc-consensus-slots",
- "sc-telemetry 28.1.0",
- "sc-transaction-pool-api 39.0.0",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-babe 0.42.1",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-inherents 36.0.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sc-telemetry 15.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-inherents 26.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3b9623ba69bb824ab62ac17b9562227b3ff488318db5cb8a5e526ea974ed81"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
  "sc-consensus-babe",
  "sc-consensus-epochs",
- "sc-rpc-api 0.48.0",
+ "sc-rpc-api 0.33.0",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-babe 0.42.1",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8732c86b70a053e32c935f63028d53fb084f88b8b9b6fee0ec19156e28fc84a3"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -13543,23 +13481,23 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sc-network 0.49.1",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-network 0.34.0",
  "sc-network-gossip",
- "sc-network-sync 0.48.0",
+ "sc-network-sync 0.33.0",
  "sc-network-types",
- "sc-utils 18.0.1",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
+ "sc-utils 14.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
  "sp-consensus-beefy",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
  "tokio",
  "wasm-timer",
@@ -13567,9 +13505,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade868a3483f51f6a864d9e0b2af6ba785088caed3e0c3d5b2ec4193b6877693"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -13577,100 +13514,96 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-consensus-beefy",
- "sc-rpc 44.0.0",
+ "sc-rpc 29.0.0",
  "serde",
- "sp-application-crypto 40.1.0",
+ "sp-application-crypto 30.0.0",
  "sp-consensus-beefy",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272475e2275a04ce5fe35a84308a9048a726eb9d571e2017548784cc979e7a9e"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "fork-tree",
+ "fork-tree 12.0.0",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sp-blockchain 39.0.0",
- "sp-runtime 41.1.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sp-blockchain 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c338eea1825f212308cc89c5d7db38810cac042da942347fa889e27fd7d8d8d"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.3",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
- "fork-tree",
+ "fork-tree 12.0.0",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "sc-block-builder 0.44.0",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
+ "sc-block-builder 0.33.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
  "sc-network-gossip",
- "sc-network-sync 0.48.0",
+ "sc-network-sync 0.33.0",
  "sc-network-types",
- "sc-telemetry 28.1.0",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
+ "sc-telemetry 15.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
  "serde_json",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea46536f937ac163d5caa5e8ba1fecb02e21288f886ea832ef60fd9b65f0bb06"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "finality-grandpa",
  "futures",
  "jsonrpsee 0.24.9",
  "log",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
+ "sc-client-api 28.0.0",
  "sc-consensus-grandpa",
- "sc-rpc 44.0.0",
+ "sc-rpc 29.0.0",
  "serde",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d1ca76d50c3f76e3629cf3228e475ae33861ba69d6eb10ba96eb1d99ccd1b"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13679,51 +13612,73 @@ dependencies = [
  "jsonrpsee 0.24.9",
  "log",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
  "sc-consensus-aura",
  "sc-consensus-babe",
  "sc-consensus-epochs",
- "sc-transaction-pool 39.0.0",
- "sc-transaction-pool-api 39.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
  "serde",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-aura 0.42.0",
- "sp-consensus-babe 0.42.1",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-timestamp 36.0.0",
- "substrate-prometheus-endpoint",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-timestamp 26.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701fd4b43e453030db70ace3d706309fbbd84096929f96a4efa96f5f22121148"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sc-telemetry 28.1.0",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-telemetry 15.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+]
+
+[[package]]
+name = "sc-executor"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-executor-common 0.29.0",
+ "sc-executor-polkavm 0.29.0",
+ "sc-executor-wasmtime 0.29.0",
+ "schnellru",
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-io 30.0.0",
+ "sp-panic-handler 13.0.0",
+ "sp-runtime-interface 24.0.0",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "sp-wasm-interface 20.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -13742,36 +13697,25 @@ dependencies = [
  "sp-core 32.0.0",
  "sp-externalities 0.28.0",
  "sp-io 34.0.0",
- "sp-panic-handler",
+ "sp-panic-handler 13.0.2",
  "sp-runtime-interface 27.0.0",
  "sp-trie 33.0.0",
  "sp-version 33.0.0",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.1",
  "tracing",
 ]
 
 [[package]]
-name = "sc-executor"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55c745bf88acb34bd606346c7de6cc06f334f627c1ff40380252a6e52ad9354"
+name = "sc-executor-common"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-executor-common 0.38.0",
- "sc-executor-polkavm 0.35.0",
- "sc-executor-wasmtime 0.38.0",
- "schnellru",
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-io 40.0.1",
- "sp-panic-handler",
- "sp-runtime-interface 29.0.1",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
- "sp-wasm-interface",
- "tracing",
+ "polkavm 0.24.0",
+ "sc-allocator 23.0.0",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0",
+ "thiserror 1.0.69",
+ "wasm-instrument",
 ]
 
 [[package]]
@@ -13782,24 +13726,21 @@ checksum = "88c61ef111d7ccc7697ee4788654f4f998662db057c27ca2de4b94f20e3e6ed1"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator 27.0.0",
- "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 21.0.1",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
 
 [[package]]
-name = "sc-executor-common"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2f84b9aa7664a9b401afbf423bcd3c1845f5adedf4f6030586808238a222df"
+name = "sc-executor-polkavm"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "polkavm 0.18.0",
- "sc-allocator 31.0.0",
- "sp-maybe-compressed-blob",
- "sp-wasm-interface",
- "thiserror 1.0.69",
- "wasm-instrument",
+ "log",
+ "polkavm 0.24.0",
+ "sc-executor-common 0.29.0",
+ "sp-wasm-interface 20.0.0",
 ]
 
 [[package]]
@@ -13811,19 +13752,23 @@ dependencies = [
  "log",
  "polkavm 0.9.3",
  "sc-executor-common 0.33.0",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.1",
 ]
 
 [[package]]
-name = "sc-executor-polkavm"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb4929b3457077f9b30ad397a724116f43f252a889ec334ec369f6cdad8f76c"
+name = "sc-executor-wasmtime"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "anyhow",
  "log",
- "polkavm 0.18.0",
- "sc-executor-common 0.38.0",
- "sp-wasm-interface",
+ "parking_lot 0.12.3",
+ "rustix 0.36.17",
+ "sc-allocator 23.0.0",
+ "sc-executor-common 0.29.0",
+ "sp-runtime-interface 24.0.0",
+ "sp-wasm-interface 20.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -13841,25 +13786,24 @@ dependencies = [
  "sc-allocator 27.0.0",
  "sc-executor-common 0.33.0",
  "sp-runtime-interface 27.0.0",
- "sp-wasm-interface",
+ "sp-wasm-interface 21.0.1",
  "wasmtime",
 ]
 
 [[package]]
-name = "sc-executor-wasmtime"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5ad79b030a1f91ef0f667e58ac35e1c9fa33a6b8a0ec1ae7fe4890322535ac"
+name = "sc-informant"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "anyhow",
+ "console",
+ "futures",
+ "futures-timer",
  "log",
- "parking_lot 0.12.3",
- "rustix 0.36.17",
- "sc-allocator 31.0.0",
- "sc-executor-common 0.38.0",
- "sp-runtime-interface 29.0.1",
- "sp-wasm-interface",
- "wasmtime",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-network-sync 0.33.0",
+ "sp-blockchain 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -13881,20 +13825,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-informant"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e979f8ccece43aa2d693bf9d4ca1830ac7155293951cdb6da40f1b28687baea"
+name = "sc-keystore"
+version = "25.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "console",
- "futures",
- "futures-timer",
- "log",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
- "sc-network-sync 0.48.0",
- "sp-blockchain 39.0.0",
- "sp-runtime 41.1.0",
+ "array-bytes 6.2.3",
+ "parking_lot 0.12.3",
+ "serde_json",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -13913,17 +13854,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-keystore"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277839ec26d67fbef7d6c87e8f34c814656c8d51433d345d862164adb3f5c2e"
+name = "sc-mixnet"
+version = "0.4.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
+ "arrayvec 0.7.6",
+ "blake2 0.10.6",
+ "bytes",
+ "futures",
+ "futures-timer",
+ "log",
+ "mixnet",
+ "parity-scale-codec",
  "parking_lot 0.12.3",
- "serde_json",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-network-types",
+ "sc-transaction-pool-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-mixnet 0.4.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
 
@@ -13958,32 +13912,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-mixnet"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4fd83a76b5a6a715a2567b762637cbc26c2f1199c8698e0603242069a6ef60"
+name = "sc-network"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
- "arrayvec 0.7.6",
- "blake2 0.10.6",
+ "async-channel 1.9.0",
+ "async-trait",
+ "asynchronous-codec 0.6.2",
  "bytes",
+ "cid 0.9.0",
+ "either",
+ "fnv",
  "futures",
  "futures-timer",
+ "ip_network",
+ "libp2p 0.54.1",
+ "linked_hash_set",
+ "litep2p",
  "log",
- "mixnet",
+ "mockall 0.13.1",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
+ "partial_sort",
+ "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.13.5",
+ "rand 0.8.5",
+ "sc-client-api 28.0.0",
+ "sc-network-common 0.33.0",
  "sc-network-types",
- "sc-transaction-pool-api 39.0.0",
- "sp-api 36.0.1",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-mixnet 0.14.0",
- "sp-runtime 41.1.0",
+ "sc-utils 14.0.0",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "unsigned-varint 0.7.2",
+ "void",
+ "wasm-timer",
+ "zeroize",
 ]
 
 [[package]]
@@ -14017,66 +13992,15 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
  "sp-blockchain 32.0.0",
  "sp-core 32.0.0",
  "sp-runtime 35.0.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "unsigned-varint 0.7.2",
- "wasm-timer",
- "zeroize",
-]
-
-[[package]]
-name = "sc-network"
-version = "0.49.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df65eb7a3c4c141de3f14b12a9832c75c7ada1fd580b0bc440263cb8ca2c5b77"
-dependencies = [
- "array-bytes 6.2.3",
- "async-channel 1.9.0",
- "async-trait",
- "asynchronous-codec 0.6.2",
- "bytes",
- "cid 0.9.0",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "ip_network",
- "libp2p 0.54.1",
- "linked_hash_set",
- "litep2p",
- "log",
- "mockall 0.13.1",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "partial_sort",
- "pin-project",
- "prost 0.12.6",
- "prost-build 0.13.5",
- "rand 0.8.5",
- "sc-client-api 39.0.0",
- "sc-network-common 0.48.0",
- "sc-network-types",
- "sc-utils 18.0.1",
- "schnellru",
- "serde",
- "serde_json",
- "smallvec",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "unsigned-varint 0.7.2",
- "void",
  "wasm-timer",
  "zeroize",
 ]
@@ -14104,6 +14028,16 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "bitflags 1.3.2",
+ "parity-scale-codec",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "sc-network-common"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98b1732616f6fd5bcdabd44eac79b466c2075f3f47ebf0cf2f6d52d790890736"
@@ -14121,34 +14055,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-network-common"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a5fc004d848bf6c1dc3cc433a0d5166dc7735ec7eb17023eff046c948c174d"
-dependencies = [
- "bitflags 1.3.2",
- "parity-scale-codec",
- "sp-runtime 41.1.0",
-]
-
-[[package]]
 name = "sc-network-gossip"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1827988c88bc075995ec11bdd0ca9f928909cbf5fef5abb33a4cdffa1f99cdb"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "ahash 0.8.11",
  "futures",
  "futures-timer",
  "log",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
- "sc-network-sync 0.48.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
+ "sc-network-sync 0.33.0",
  "sc-network-types",
  "schnellru",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "tracing",
+]
+
+[[package]]
+name = "sc-network-light"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel 1.9.0",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build 0.13.5",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
+ "sc-network-types",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14174,25 +14117,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-network-light"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc00bf32b686d3f25e7697fb40d20bc0654ac2ddc7c03fc641246f40d76af2da"
+name = "sc-network-sync"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
+ "async-trait",
+ "fork-tree 12.0.0",
  "futures",
  "log",
+ "mockall 0.13.1",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build 0.13.5",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
+ "sc-client-api 28.0.0",
+ "sc-consensus 0.33.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
  "sc-network-types",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sc-utils 14.0.0",
+ "schnellru",
+ "smallvec",
+ "sp-arithmetic 23.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -14204,7 +14160,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
- "fork-tree",
+ "fork-tree 13.0.1",
  "futures",
  "futures-timer",
  "libp2p 0.51.4",
@@ -14220,52 +14176,35 @@ dependencies = [
  "sc-utils 17.0.0",
  "schnellru",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
  "sp-blockchain 32.0.0",
  "sp-consensus 0.36.0",
  "sp-consensus-grandpa 17.0.0",
  "sp-core 32.0.0",
  "sp-runtime 35.0.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
-name = "sc-network-sync"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d22f0e1c117901ac5ba27df45a34928ff485741b8300809e2fdd812208020eb"
+name = "sc-network-transactions"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
- "async-channel 1.9.0",
- "async-trait",
- "fork-tree",
  "futures",
  "log",
- "mockall 0.13.1",
  "parity-scale-codec",
- "prost 0.12.6",
- "prost-build 0.13.5",
- "sc-client-api 39.0.0",
- "sc-consensus 0.48.0",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
+ "sc-network-sync 0.33.0",
  "sc-network-types",
- "sc-utils 18.0.1",
- "schnellru",
- "smallvec",
- "sp-arithmetic",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
+ "sc-utils 14.0.0",
+ "sp-consensus 0.32.0",
+ "sp-runtime 31.0.1",
+ "substrate-prometheus-endpoint 0.17.0",
 ]
 
 [[package]]
@@ -14285,34 +14224,13 @@ dependencies = [
  "sc-utils 17.0.0",
  "sp-consensus 0.36.0",
  "sp-runtime 35.0.0",
- "substrate-prometheus-endpoint",
-]
-
-[[package]]
-name = "sc-network-transactions"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0443ceff666e09504981eb10da28d0e959276fc713792a23586e01132100a49a"
-dependencies = [
- "array-bytes 6.2.3",
- "futures",
- "log",
- "parity-scale-codec",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
- "sc-network-sync 0.48.0",
- "sc-network-types",
- "sc-utils 18.0.1",
- "sp-consensus 0.42.0",
- "sp-runtime 41.1.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
 ]
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff910b7a20f14b1a77b2616de21d509cf51ce1a006e30b2d1f293a8fae72555"
+version = "0.10.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bs58 0.5.1",
  "bytes",
@@ -14330,9 +14248,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721798adf89fdf7068912c91cae8b7174bb561201a54ba7b788ae2ef36da154d"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "bytes",
  "fnv",
@@ -14348,29 +14265,60 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustls 0.23.26",
- "sc-client-api 39.0.0",
- "sc-network 0.49.1",
+ "sc-client-api 28.0.0",
+ "sc-network 0.34.0",
  "sc-network-types",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-keystore 0.42.0",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-keystore 0.34.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
  "threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872046dabf12aef8cdc6a67a9c5bcb4fc34fb7f2d8a664ed2028aaf2717895f1"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "log",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.0",
+]
+
+[[package]]
+name = "sc-rpc"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "futures",
+ "jsonrpsee 0.24.9",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-block-builder 0.33.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
+ "sc-mixnet 0.4.0",
+ "sc-rpc-api 0.33.0",
+ "sc-tracing 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
+ "serde_json",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-offchain 26.0.0",
+ "sp-rpc 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-statement-store 10.0.0",
+ "sp-version 29.0.0",
+ "tokio",
 ]
 
 [[package]]
@@ -14407,36 +14355,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-rpc"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf313ac99a06ececd9576909c5fc688a6e22c60997fa1b8a58035f4ff1e861bf"
+name = "sc-rpc-api"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "futures",
  "jsonrpsee 0.24.9",
- "log",
  "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-block-builder 0.44.0",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
- "sc-mixnet 0.19.0",
- "sc-rpc-api 0.48.0",
- "sc-tracing 39.0.0",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
+ "sc-chain-spec 28.0.0",
+ "sc-mixnet 0.4.0",
+ "sc-transaction-pool-api 28.0.0",
+ "scale-info",
+ "serde",
  "serde_json",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-offchain 36.0.0",
- "sp-rpc 34.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-statement-store 20.1.0",
- "sp-version 39.0.0",
- "tokio",
+ "sp-core 28.0.0",
+ "sp-rpc 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14461,24 +14396,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-rpc-api"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed810a156f70cf5f7ab8fb5d9cf818999a72821c570aba4f4699aa4eea59e01"
+name = "sc-rpc-server"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "dyn-clone",
+ "forwarded-header-value",
+ "futures",
+ "governor",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "ip_network",
  "jsonrpsee 0.24.9",
- "parity-scale-codec",
- "sc-chain-spec 42.0.0",
- "sc-mixnet 0.19.0",
- "sc-transaction-pool-api 39.0.0",
- "scale-info",
+ "log",
+ "sc-rpc-api 0.33.0",
  "serde",
  "serde_json",
- "sp-core 36.1.0",
- "sp-rpc 34.0.0",
- "sp-runtime 41.1.0",
- "sp-version 39.0.0",
- "thiserror 1.0.69",
+ "substrate-prometheus-endpoint 0.17.0",
+ "tokio",
+ "tower",
+ "tower-http 0.5.2",
 ]
 
 [[package]]
@@ -14494,35 +14432,43 @@ dependencies = [
  "jsonrpsee 0.22.5",
  "log",
  "serde_json",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "tokio",
  "tower",
  "tower-http 0.4.4",
 ]
 
 [[package]]
-name = "sc-rpc-server"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c7a0a366367b1a3480af1327cd7d841806edc7f46da485e2c36064ad98a7c5"
+name = "sc-rpc-spec-v2"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "dyn-clone",
- "forwarded-header-value",
+ "array-bytes 6.2.3",
  "futures",
- "governor",
- "http 1.3.1",
- "http-body-util",
- "hyper 1.6.0",
- "ip_network",
+ "futures-util",
+ "hex",
+ "itertools 0.11.0",
  "jsonrpsee 0.24.9",
  "log",
- "sc-rpc-api 0.48.0",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
+ "sc-rpc 29.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "schnellru",
  "serde",
- "serde_json",
- "substrate-prometheus-endpoint",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-rpc 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
+ "thiserror 1.0.69",
  "tokio",
- "tower",
- "tower-http 0.5.2",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -14558,52 +14504,82 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-rpc-spec-v2"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d0d0145ce4fcfb3a587391a4276a8bf504c4d9efe962d9c9a4f7e6580242f"
+name = "sc-runtime-utilities"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "array-bytes 6.2.3",
+ "parity-scale-codec",
+ "sc-executor 0.32.0",
+ "sc-executor-common 0.29.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-state-machine 0.35.0",
+ "sp-wasm-interface 20.0.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-service"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "async-trait",
+ "directories",
+ "exit-future",
  "futures",
- "futures-util",
- "hex",
- "itertools 0.11.0",
+ "futures-timer",
  "jsonrpsee 0.24.9",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "pin-project",
  "rand 0.8.5",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
- "sc-rpc 44.0.0",
- "sc-transaction-pool-api 39.0.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
+ "sc-client-db 0.35.0",
+ "sc-consensus 0.33.0",
+ "sc-executor 0.32.0",
+ "sc-informant 0.33.0",
+ "sc-keystore 25.0.0",
+ "sc-network 0.34.0",
+ "sc-network-common 0.33.0",
+ "sc-network-light 0.33.0",
+ "sc-network-sync 0.33.0",
+ "sc-network-transactions 0.33.0",
+ "sc-network-types",
+ "sc-rpc 29.0.0",
+ "sc-rpc-server 11.0.0",
+ "sc-rpc-spec-v2 0.34.0",
+ "sc-sysinfo 27.0.0",
+ "sc-telemetry 15.0.0",
+ "sc-tracing 28.0.0",
+ "sc-transaction-pool 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
  "schnellru",
  "serde",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-rpc 34.0.0",
- "sp-runtime 41.1.0",
- "sp-version 39.0.0",
+ "serde_json",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-transaction-storage-proof 26.0.0",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "static_init",
+ "substrate-prometheus-endpoint 0.17.0",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "sc-runtime-utilities"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb39eaa0993635be94a5d5171f75ed81b7149cfcf435725581ee968d9d9b563f"
-dependencies = [
- "parity-scale-codec",
- "sc-executor 0.42.0",
- "sc-executor-common 0.38.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-state-machine 0.45.0",
- "sp-wasm-interface",
- "thiserror 1.0.69",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -14663,7 +14639,7 @@ dependencies = [
  "sp-trie 33.0.0",
  "sp-version 33.0.0",
  "static_init",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -14672,68 +14648,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-service"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0204f65df1d1cf22c6fb63f5268132468261520aa66943bd37d59a61b8241322"
+name = "sc-state-db"
+version = "0.30.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
- "directories",
- "exit-future",
- "futures",
- "futures-timer",
- "jsonrpsee 0.24.9",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
- "sc-client-db 0.46.0",
- "sc-consensus 0.48.0",
- "sc-executor 0.42.0",
- "sc-informant 0.48.0",
- "sc-keystore 35.0.0",
- "sc-network 0.49.1",
- "sc-network-common 0.48.0",
- "sc-network-light 0.48.0",
- "sc-network-sync 0.48.0",
- "sc-network-transactions 0.48.0",
- "sc-network-types",
- "sc-rpc 44.0.0",
- "sc-rpc-server 21.0.0",
- "sc-rpc-spec-v2 0.49.0",
- "sc-sysinfo 42.0.0",
- "sc-telemetry 28.1.0",
- "sc-tracing 39.0.0",
- "sc-transaction-pool 39.0.0",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
- "schnellru",
- "serde",
- "serde_json",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-state-machine 0.45.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-transaction-storage-proof 36.1.0",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
- "static_init",
- "substrate-prometheus-endpoint",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
+ "sp-core 28.0.0",
 ]
 
 [[package]]
@@ -14749,49 +14671,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-state-db"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4a6610694637ad5e54ddd6af421178e23353443893213c0c2eb31344b65cd5"
-dependencies = [
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 36.1.0",
-]
-
-[[package]]
 name = "sc-storage-monitor"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3864e37a1ed05f14b5ab979d84bb6e93dc422312b9850e55e9f6c1004dbdb1ac"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core 36.1.0",
+ "sp-core 28.0.0",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84f29951101c51c11e5206d5a69106d184edffc7b96f62ecc5bf4c7788de6bc"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
- "sc-chain-spec 42.0.0",
- "sc-client-api 39.0.0",
+ "sc-chain-spec 28.0.0",
+ "sc-client-api 28.0.0",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-consensus-grandpa",
  "serde",
  "serde_json",
- "sp-blockchain 39.0.0",
- "sp-runtime 41.1.0",
+ "sp-blockchain 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-sysinfo"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "derive_more 0.99.19",
+ "futures",
+ "libc",
+ "log",
+ "rand 0.8.5",
+ "rand_pcg",
+ "regex",
+ "sc-telemetry 15.0.0",
+ "serde",
+ "serde_json",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-io 30.0.0",
 ]
 
 [[package]]
@@ -14811,30 +14739,28 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-io 34.0.0",
- "sp-std",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "sc-sysinfo"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadd799aae2a1ac6eac8edcbcfba533ae4aadbf2c7e8449f530fd98b5be7cd9"
+name = "sc-telemetry"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "derive_more 0.99.19",
+ "chrono",
  "futures",
- "libc",
+ "libp2p 0.54.1",
  "log",
+ "parking_lot 0.12.3",
+ "pin-project",
  "rand 0.8.5",
- "rand_pcg",
- "regex",
- "sc-telemetry 28.1.0",
+ "sc-utils 14.0.0",
  "serde",
  "serde_json",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-io 40.0.1",
+ "thiserror 1.0.69",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -14858,23 +14784,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-telemetry"
-version = "28.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d751fd77c6a8d1a5bca8cb5df9d9c57f77b4b15e84eab07925b0f76ddee3e74"
+name = "sc-tracing"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "chrono",
- "futures",
- "libp2p 0.54.1",
+ "console",
+ "is-terminal",
+ "libc",
  "log",
+ "parity-scale-codec",
  "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "sc-utils 18.0.1",
+ "rustc-hash 1.1.0",
+ "sc-client-api 28.0.0",
+ "sc-tracing-proc-macro 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "serde",
- "serde_json",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-rpc 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.69",
- "wasm-timer",
+ "tracing",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -14894,47 +14828,18 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "sc-client-api 32.0.0",
- "sc-tracing-proc-macro",
+ "sc-tracing-proc-macro 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sp-api 30.0.0",
  "sp-blockchain 32.0.0",
  "sp-core 32.0.0",
  "sp-rpc 30.0.0",
  "sp-runtime 35.0.0",
- "sp-tracing",
+ "sp-tracing 17.1.0",
  "thiserror 1.0.69",
  "tracing",
  "tracing-log 0.1.4",
  "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "sc-tracing"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97765091d1e29f00bc0ab13149b1922c89dd60b66069e1016a9eb4b289171e3"
-dependencies = [
- "chrono",
- "console",
- "is-terminal",
- "libc",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rustc-hash 1.1.0",
- "sc-client-api 39.0.0",
- "sc-tracing-proc-macro",
- "serde",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-rpc 34.0.0",
- "sp-runtime 41.1.0",
- "sp-tracing",
- "thiserror 1.0.69",
- "tracing",
- "tracing-log 0.2.0",
- "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -14947,6 +14852,48 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "sc-tracing-proc-macro"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sc-transaction-pool"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "indexmap 2.9.0",
+ "itertools 0.11.0",
+ "linked-hash-map",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-client-api 28.0.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sc-utils 14.0.0",
+ "serde",
+ "sp-api 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
+ "sp-transaction-pool 26.0.0",
+ "substrate-prometheus-endpoint 0.17.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -14969,45 +14916,29 @@ dependencies = [
  "sp-api 30.0.0",
  "sp-blockchain 32.0.0",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 35.0.0",
- "sp-tracing",
+ "sp-tracing 17.1.0",
  "sp-transaction-pool 30.0.0",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.17.2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "sc-transaction-pool"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db819d511819f146c5b4d6c2d75aaf1aaad6045b4644ce8528bfa300a621790a"
+name = "sc-transaction-pool-api"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "futures",
- "futures-timer",
  "indexmap 2.9.0",
- "itertools 0.11.0",
- "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-client-api 39.0.0",
- "sc-transaction-pool-api 39.0.0",
- "sc-utils 18.0.1",
  "serde",
- "sp-api 36.0.1",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-runtime 41.1.0",
- "sp-tracing",
- "sp-transaction-pool 36.0.0",
- "substrate-prometheus-endpoint",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -15028,21 +14959,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-transaction-pool-api"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55feca303d4ba839f02261c9a73d40f6b0ac7523882b4008472922b934678729"
+name = "sc-utils"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
+ "async-channel 1.9.0",
  "futures",
- "indexmap 2.9.0",
+ "futures-timer",
  "log",
- "parity-scale-codec",
- "serde",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "thiserror 1.0.69",
+ "parking_lot 0.12.3",
+ "prometheus",
+ "sp-arithmetic 23.0.0",
 ]
 
 [[package]]
@@ -15058,29 +14985,14 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic",
-]
-
-[[package]]
-name = "sc-utils"
-version = "18.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8879d46892f1378ff633692740d0a5cb13777ee6dafe84d7e9b954b1e6753"
-dependencies = [
- "async-channel 1.9.0",
- "futures",
- "futures-timer",
- "log",
- "parking_lot 0.12.3",
- "prometheus",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
 ]
 
 [[package]]
 name = "scale-bits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+checksum = "27243ab0d2d6235072b017839c5f0cd1a3b1ce45c0f7a715363b0c7d36c76c94"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15090,24 +15002,24 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ae9cc099ae85ff28820210732b00f019546f36f33225f509fe25d5816864a0"
+checksum = "4d78196772d25b90a98046794ce0fe2588b39ebdfbdc1e45b4c6c85dd43bebad"
 dependencies = [
- "derive_more 1.0.0",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-decode-derive",
  "scale-type-resolver",
  "smallvec",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed9401effa946b493f9f84dc03714cca98119b230497df6f3df6b84a2b03648"
+checksum = "2f4b54a1211260718b92832b661025d1f1a4b6930fbadd6908e00edd265fa5f7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -15117,24 +15029,24 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9271284d05d0749c40771c46180ce89905fd95aa72a2a2fddb4b7c0aa424db"
+checksum = "64901733157f9d25ef86843bd783eda439fac7efb0ad5a615d12d2cf3a29464b"
 dependencies = [
- "derive_more 1.0.0",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-encode-derive",
  "scale-type-resolver",
  "smallvec",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102fbc6236de6c53906c0b262f12c7aa69c2bdc604862c12728f5f4d370bc137"
+checksum = "78a3993a13b4eafa89350604672c8757b7ea84c7c5947d4b3691e3169c96379b"
 dependencies = [
  "darling",
  "proc-macro-crate 3.3.0",
@@ -15181,34 +15093,33 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc4c70c7fea2eef1740f0081d3fe385d8bee1eef11e9272d3bec7dc8e5438e0"
+checksum = "05c61b6b706a3eaad63b506ab50a1d2319f817ae01cf753adcc3f055f9f0fcd6"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
  "syn 2.0.100",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e0ef2a0ee1e02a69ada37feb87ea1616ce9808aca072befe2d3131bf28576e"
+checksum = "8ca8b26b451ecb7fd7b62b259fa28add63d12ec49bbcac0e01fcb4b5ae0c09aa"
 dependencies = [
  "base58",
  "blake2 0.10.6",
- "derive_more 1.0.0",
  "either",
  "parity-scale-codec",
  "scale-bits",
  "scale-decode",
  "scale-encode",
- "scale-info",
  "scale-type-resolver",
  "serde",
+ "thiserror 2.0.12",
  "yap",
 ]
 
@@ -15711,14 +15622,13 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309676378797233b566bb26fb7f7f9829ae97f988b53a1f7268dd0ad17d47902"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -16028,6 +15938,28 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "docify",
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 15.0.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-metadata-ir 0.6.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sp-api"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8abd1d0732054ad896db8f092abe822106f1acf8bbc462c70f57d0f24c0dcdf"
@@ -16043,33 +15975,24 @@ dependencies = [
  "sp-runtime 35.0.0",
  "sp-runtime-interface 27.0.0",
  "sp-state-machine 0.39.0",
- "sp-std",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-trie 33.0.0",
  "sp-version 33.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "sp-api"
-version = "36.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541da427f47dfb97f3dd0556fa3272bdc5dfa0d4c1ad53a22670a9bae4db63d7"
+name = "sp-api-proc-macro"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 22.0.0",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-metadata-ir 0.10.0",
- "sp-runtime 41.1.0",
- "sp-runtime-interface 29.0.1",
- "sp-state-machine 0.45.0",
- "sp-trie 39.1.0",
- "sp-version 39.0.0",
- "thiserror 1.0.69",
+ "Inflector",
+ "blake2 0.10.6",
+ "expander",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -16088,18 +16011,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-api-proc-macro"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36334085c348bb507debd40e604f71194b1fc669eb6fec81aebef08eb3466f6c"
+name = "sp-application-crypto"
+version = "30.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
 ]
 
 [[package]]
@@ -16113,20 +16033,21 @@ dependencies = [
  "serde",
  "sp-core 32.0.0",
  "sp-io 34.0.0",
- "sp-std",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "sp-application-crypto"
-version = "40.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba375ab65a76f7413d1bfe48122fd347ce7bd2047e36ecbbd78f12f5adaed121"
+name = "sp-arithmetic"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "docify",
+ "integer-sqrt",
+ "num-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
+ "static_assertions",
 ]
 
 [[package]]
@@ -16146,15 +16067,24 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fc2f6c59c333eef805edcec5e603dd8e3a94e20fddb6b19cb914c9f3be7ad5"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-runtime 41.1.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "sp-block-builder"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "sp-api 26.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -16169,14 +16099,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-block-builder"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a165b95a2f03d9c09c3e51ac3f23d27b091543a41cd3b3df1348aa5917d01eca"
+name = "sp-blockchain"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-api 36.0.1",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "schnellru",
+ "sp-api 26.0.0",
+ "sp-consensus 0.32.0",
+ "sp-core 28.0.0",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
@@ -16192,30 +16130,24 @@ dependencies = [
  "schnellru",
  "sp-api 30.0.0",
  "sp-consensus 0.36.0",
- "sp-database",
+ "sp-database 10.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 35.0.0",
  "sp-state-machine 0.39.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "sp-blockchain"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afbe184cfe66895497cdfac1ab2927d85294b9c3bcc2c734798994d08b95db6"
+name = "sp-consensus"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "async-trait",
  "futures",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "schnellru",
- "sp-api 36.0.1",
- "sp-consensus 0.42.0",
- "sp-core 36.1.0",
- "sp-database",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
+ "log",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -16235,18 +16167,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5fed2e52d0cbf8ddc39a5bb7211f19a26f15f70a6c8d964ee05fc73b64e6c3"
+name = "sp-consensus-aura"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
- "futures",
- "log",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "thiserror 1.0.69",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-timestamp 26.0.0",
 ]
 
 [[package]]
@@ -16267,20 +16200,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-aura"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f3b3414e7620ad72d0000b520e0570dca38dc63e160c95164ff3f789020cc1"
+name = "sp-consensus-babe"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-consensus-slots 0.42.1",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-timestamp 36.0.0",
+ "serde",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-timestamp 26.0.0",
 ]
 
 [[package]]
@@ -16303,43 +16237,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-babe"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54310103ae4f0e3228e217e2a9ccaca0d7c3502d3aa276623febf4c722ca397"
+name = "sp-consensus-beefy"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-consensus-slots 0.42.1",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-timestamp 36.0.0",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-io 30.0.0",
+ "sp-keystore 0.34.0",
+ "sp-mmr-primitives",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
+ "strum 0.26.3",
 ]
 
 [[package]]
-name = "sp-consensus-beefy"
-version = "24.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ecab3df80c73555434cee450c3d3c5350e91173f684cd0fc4d33a057d882f"
+name = "sp-consensus-grandpa"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "finality-grandpa",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-io 40.0.1",
- "sp-keystore 0.42.0",
- "sp-mmr-primitives",
- "sp-runtime 41.1.0",
- "sp-weights",
- "strum 0.26.3",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -16361,21 +16292,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-grandpa"
-version = "23.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e969d551ce631fbaf190a4457c295ef70c50bae657602f2377e433f9454868"
+name = "sp-consensus-slots"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "finality-grandpa",
- "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
+ "sp-timestamp 26.0.0",
 ]
 
 [[package]]
@@ -16391,15 +16315,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-slots"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc83d9e7b1d58e1d020c20d7208b00d21fa73dcf92721114eae432b9f01e62d5"
+name = "sp-core"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "ark-vrf",
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "dyn-clone",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde 0.5.0",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
  "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types 0.13.1",
+ "rand 0.8.5",
  "scale-info",
+ "schnorrkel 0.11.4",
+ "secp256k1 0.28.2",
+ "secrecy 0.8.0",
  "serde",
- "sp-timestamp 36.0.0",
+ "sha2 0.10.8",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-runtime-interface 24.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0",
+ "ss58-registry",
+ "substrate-bip39 0.4.7",
+ "thiserror 1.0.69",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
 ]
 
 [[package]]
@@ -16435,62 +16395,14 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.28.0",
  "sp-runtime-interface 27.0.0",
- "sp-std",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39",
- "thiserror 1.0.69",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbb58c21e6b27f2aadf3ff0c8b20a8ead13b9dfe63f46717fd59334517f3b4"
-dependencies = [
- "ark-vrf",
- "array-bytes 6.2.3",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58 0.5.1",
- "dyn-clonable",
- "ed25519-zebra 4.0.3",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde 0.5.0",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types 0.13.1",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel 0.11.4",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
- "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities 0.30.0",
- "sp-runtime-interface 29.0.1",
- "sp-std",
- "sp-storage 22.0.0",
- "ss58-registry",
- "substrate-bip39",
+ "substrate-bip39 0.6.0",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -16512,13 +16424,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-crypto-hashing"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "digest 0.10.7",
+ "sha2 0.10.8",
+ "sha3",
+ "twox-hash",
+]
+
+[[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sp-crypto-hashing-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "quote",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "syn 2.0.100",
 ]
 
@@ -16527,6 +16462,15 @@ name = "sp-database"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
+dependencies = [
+ "kvdb",
+ "parking_lot 0.12.3",
+]
+
+[[package]]
+name = "sp-database"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -16544,6 +16488,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-debug-derive"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.25.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-storage 19.0.0",
+]
+
+[[package]]
 name = "sp-externalities"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16555,14 +16519,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-externalities"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cbf059dce180a8bf8b6c8b08b6290fa3d1c7f069a60f1df038ab5dd5fc0ba6"
+name = "sp-genesis-builder"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "environmental",
  "parity-scale-codec",
- "sp-storage 22.0.0",
+ "scale-info",
+ "serde_json",
+ "sp-api 26.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -16577,16 +16542,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-genesis-builder"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb0d996dfce9afb8879bdfbba9cb9a7d06f29fda38168b91e90419b3b92c42e"
+name = "sp-inherents"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "serde_json",
- "sp-api 36.0.1",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -16604,17 +16569,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-inherents"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb09ff07946f3e1ecdd4bfb40b2cceba60188215ceb941b5b07230294d7aee1"
+name = "sp-io"
+version = "30.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
+ "bytes",
+ "docify",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
  "parity-scale-codec",
- "scale-info",
- "sp-runtime 41.1.0",
- "thiserror 1.0.69",
+ "polkavm-derive 0.24.0",
+ "rustversion",
+ "secp256k1 0.28.2",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime-interface 24.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-tracing 16.0.0",
+ "sp-trie 29.0.0",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -16632,43 +16609,26 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.28.0",
  "sp-keystore 0.38.0",
  "sp-runtime-interface 27.0.0",
  "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 17.1.0",
  "sp-trie 33.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
-name = "sp-io"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e41d010bcc515d119901ff7ac83150c335d543c7f6c03be5c8fe08430b8a03b"
+name = "sp-keyring"
+version = "31.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-externalities 0.30.0",
- "sp-keystore 0.42.0",
- "sp-runtime-interface 29.0.1",
- "sp-state-machine 0.45.0",
- "sp-tracing",
- "sp-trie 39.1.0",
- "tracing",
- "tracing-core",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -16683,14 +16643,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-keyring"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c601d506585c0bcee79dbde401251b127af5f04c7373fc3cf7d6a6b7f6b970a3"
+name = "sp-keystore"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "strum 0.26.3",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
 ]
 
 [[package]]
@@ -16706,18 +16666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-keystore"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f893398a5330e28f219662c7a0afa174fb068d8f82d2a9990016c4b0bc4369"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
-]
-
-[[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16725,6 +16673,25 @@ checksum = "f0c768c11afbe698a090386876911da4236af199cd38a5866748df4d8628aeff"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
+]
+
+[[package]]
+name = "sp-maybe-compressed-blob"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "thiserror 1.0.69",
+ "zstd 0.12.4",
+]
+
+[[package]]
+name = "sp-metadata-ir"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "frame-metadata 23.0.0",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -16739,14 +16706,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-metadata-ir"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d1db25e362edbf5531b427d4bdfc2562bec6a031c3eb2a9145c0a0a01a572d"
+name = "sp-mixnet"
+version = "0.4.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-info",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
 ]
 
 [[package]]
@@ -16762,47 +16729,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-mixnet"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e65fb51d9ff444789b3c7771a148d7b685ec3c02498792fd0ecae0f1e00218f"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
-]
-
-[[package]]
 name = "sp-mmr-primitives"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ebcc2d106515a20ecf22b8d41d69e710f8e860849afde777ff73cb46f1bf29"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "log",
  "parity-scale-codec",
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-debug-derive",
- "sp-runtime 41.1.0",
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214e59764b21445b9ec5cb9623df68b765682e34c75f4bd27522e629d7e62fd4"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "sp-offchain"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -16817,14 +16780,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-offchain"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5ac60e48200d7b7f61681320deaf06bdced47cfd5f1cb4589b533b58fa4da4"
+name = "sp-panic-handler"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "backtrace",
+ "regex",
 ]
 
 [[package]]
@@ -16839,6 +16800,16 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "rustc-hash 1.1.0",
+ "serde",
+ "sp-core 28.0.0",
+]
+
+[[package]]
+name = "sp-rpc"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51104c3cab9d6c9e8361adbd487dd409a8343e740744fb0b3f983bc775fd1847"
@@ -16849,14 +16820,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-rpc"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acde213e9f08065dcc407a934e9ffd5388bef51347326195405efb62c7a0e4a"
+name = "sp-runtime"
+version = "31.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "rustc-hash 1.1.0",
+ "binary-merkle-tree",
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
  "serde",
- "sp-core 36.1.0",
+ "simple-mermaid",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-trie 29.0.0",
+ "sp-weights 27.0.0",
+ "tracing",
+ "tuplex",
 ]
 
 [[package]]
@@ -16877,41 +16866,30 @@ dependencies = [
  "serde",
  "simple-mermaid",
  "sp-application-crypto 34.0.0",
- "sp-arithmetic",
+ "sp-arithmetic 26.1.0",
  "sp-core 32.0.0",
  "sp-io 34.0.0",
- "sp-std",
- "sp-weights",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-weights 31.1.0",
 ]
 
 [[package]]
-name = "sp-runtime"
-version = "41.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3864101a28faba3d8eca026e3f56ea20dd1d979ce1bcc20152e86c9d82be52bf"
+name = "sp-runtime-interface"
+version = "24.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "binary-merkle-tree",
- "docify",
- "either",
- "hash256-std-hasher",
+ "bytes",
  "impl-trait-for-tuples",
- "log",
- "num-traits",
  "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-std",
- "sp-trie 39.1.0",
- "sp-weights",
- "tracing",
- "tuplex",
+ "polkavm-derive 0.24.0",
+ "primitive-types 0.13.1",
+ "sp-externalities 0.25.0",
+ "sp-runtime-interface-proc-macro 17.0.0",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0",
+ "sp-tracing 16.0.0",
+ "sp-wasm-interface 20.0.0",
+ "static_assertions",
 ]
 
 [[package]]
@@ -16926,32 +16904,25 @@ dependencies = [
  "polkavm-derive 0.9.1",
  "primitive-types 0.12.2",
  "sp-externalities 0.28.0",
- "sp-runtime-interface-proc-macro",
- "sp-std",
+ "sp-runtime-interface-proc-macro 18.0.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-tracing 17.1.0",
+ "sp-wasm-interface 21.0.1",
  "static_assertions",
 ]
 
 [[package]]
-name = "sp-runtime-interface"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99db36a7aff44c335f5d5b36c182a3e0cac61de2fefbe2eeac6af5fb13f63bf"
+name = "sp-runtime-interface-proc-macro"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.30.0",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-storage 22.0.0",
- "sp-tracing",
- "sp-wasm-interface",
- "static_assertions",
+ "Inflector",
+ "expander",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -16970,6 +16941,20 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 26.0.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+]
+
+[[package]]
+name = "sp-session"
 version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d66f0f2f00e4c520deae07eeab7acf04c1a41dd875c7a4689e4e4302fb89925"
@@ -16984,18 +16969,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-session"
-version = "38.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4158c5558192b56cf5ba2ea028cbdbf0fc7c65258e5aa7653bdfad6e68ed21"
+name = "sp-staking"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-core 36.1.0",
- "sp-keystore 0.42.0",
- "sp-runtime 41.1.0",
- "sp-staking 38.0.0",
+ "serde",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -17013,17 +16996,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-staking"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8f9c0a32836e3c8842b0aec0813077654885d45d83b618210fbb730ea63545"
+name = "sp-state-machine"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "impl-trait-for-tuples",
+ "hash-db",
+ "log",
  "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-panic-handler 13.0.0",
+ "sp-trie 29.0.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "trie-db 0.30.0",
 ]
 
 [[package]]
@@ -17040,7 +17029,7 @@ dependencies = [
  "smallvec",
  "sp-core 32.0.0",
  "sp-externalities 0.28.0",
- "sp-panic-handler",
+ "sp-panic-handler 13.0.2",
  "sp-trie 33.0.0",
  "thiserror 1.0.69",
  "tracing",
@@ -17048,24 +17037,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-state-machine"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206508475c01ae2e14f171d35d7fc3eaa7278140d7940416591d49a784792ed6"
+name = "sp-statement-store"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "hash-db",
- "log",
+ "aes-gcm",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek",
+ "hkdf",
  "parity-scale-codec",
- "parking_lot 0.12.3",
  "rand 0.8.5",
- "smallvec",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
- "sp-panic-handler",
- "sp-trie 39.1.0",
+ "scale-info",
+ "sha2 0.10.8",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
  "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
+ "x25519-dalek 2.0.1",
 ]
 
 [[package]]
@@ -17085,35 +17077,10 @@ dependencies = [
  "sp-api 30.0.0",
  "sp-application-crypto 34.0.0",
  "sp-core 32.0.0",
- "sp-crypto-hashing",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.28.0",
  "sp-runtime 35.0.0",
  "sp-runtime-interface 27.0.0",
- "thiserror 1.0.69",
- "x25519-dalek 2.0.1",
-]
-
-[[package]]
-name = "sp-statement-store"
-version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6633564ef0b4179c3109855b8480673dea40bd0c11a46e89fa7b7fc526e65de"
-dependencies = [
- "aes-gcm",
- "curve25519-dalek 4.1.3",
- "ed25519-dalek",
- "hkdf",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sha2 0.10.8",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-core 36.1.0",
- "sp-crypto-hashing",
- "sp-externalities 0.30.0",
- "sp-runtime 41.1.0",
- "sp-runtime-interface 29.0.1",
  "thiserror 1.0.69",
  "x25519-dalek 2.0.1",
 ]
@@ -17125,6 +17092,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
+name = "sp-std"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+
+[[package]]
+name = "sp-storage"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "impl-serde 0.5.0",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+]
+
+[[package]]
 name = "sp-storage"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17134,20 +17118,19 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "sp-storage"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3b70ca340e41cde9d2e069d354508a6e37a6573d66f7cc38f11549002f64ec"
+name = "sp-timestamp"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "impl-serde 0.5.0",
+ "async-trait",
  "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -17164,16 +17147,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-timestamp"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176c77326c15425a15e085261161a9435f9a3c0d4bf61dae6dccf05b957a51c6"
+name = "sp-tracing"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
  "parity-scale-codec",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "thiserror 1.0.69",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -17190,6 +17171,15 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "sp-api 26.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "sp-transaction-pool"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddae32e6935eedda993b7371b79e69af901a277e11be2bbd6d9bc7643b49cb"
@@ -17199,13 +17189,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-transaction-pool"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fe2b97ebbbdbaab7200914f5fa3e3493972fceb39d3fb9324bc5b63f60a994"
+name = "sp-transaction-storage-proof"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "sp-api 36.0.1",
- "sp-runtime 41.1.0",
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-trie 29.0.0",
 ]
 
 [[package]]
@@ -17224,18 +17218,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-transaction-storage-proof"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc175a54170879cc504306e08650d96091e4b9f033b20f4ee542dc9b61b5fd"
+name = "sp-trie"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "async-trait",
+ "ahash 0.8.11",
+ "hash-db",
+ "memory-db 0.33.0",
+ "nohash-hasher",
  "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
  "scale-info",
- "sp-core 36.1.0",
- "sp-inherents 36.0.0",
- "sp-runtime 41.1.0",
- "sp-trie 39.1.0",
+ "schnellru",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "substrate-prometheus-endpoint 0.17.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "trie-db 0.30.0",
+ "trie-root",
 ]
 
 [[package]]
@@ -17247,7 +17249,7 @@ dependencies = [
  "ahash 0.8.11",
  "hash-db",
  "lazy_static",
- "memory-db",
+ "memory-db 0.32.0",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -17263,26 +17265,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-trie"
-version = "39.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a555bf4c42ca89e2e7bf2f11308806dad13cdbd7f8fd60cf2649f12b6ee809bf"
+name = "sp-version"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "memory-db",
- "nohash-hasher",
+ "impl-serde 0.5.0",
  "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
+ "parity-wasm",
  "scale-info",
- "schnellru",
- "sp-core 36.1.0",
- "sp-externalities 0.30.0",
+ "serde",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime 31.0.1",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-version-proc-macro 13.0.0",
  "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
- "trie-root",
 ]
 
 [[package]]
@@ -17296,29 +17292,23 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro",
+ "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 35.0.0",
- "sp-std",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-version-proc-macro 14.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "sp-version"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd736a15ff2ea0a67c5a3bbdfd842d88f11f0774d7701a8d8a316f8deba276c5"
+name = "sp-version-proc-macro"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "impl-serde 0.5.0",
  "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 41.1.0",
- "sp-std",
- "sp-version-proc-macro 15.0.0",
- "thiserror 1.0.69",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -17334,16 +17324,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-version-proc-macro"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cabc8279e835cd9c608d70cb00e693bddec94fe8478e9f3104dad1da5f93ca"
+name = "sp-wasm-interface"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
+ "anyhow",
+ "impl-trait-for-tuples",
+ "log",
  "parity-scale-codec",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "wasmtime",
 ]
 
 [[package]]
@@ -17361,6 +17350,20 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "bounded-collections",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 23.0.0",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+]
+
+[[package]]
+name = "sp-weights"
 version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "515aa194eabac059041df2dbee75b059b99981213ec680e9de85b45b6988346a"
@@ -17370,8 +17373,8 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic",
- "sp-debug-derive",
+ "sp-arithmetic 26.1.0",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -17439,48 +17442,45 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67defdbfcd90bf9b8d4794d2287a27908e518d0540fe8a15bed7761eb07a7e3"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 41.1.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
 name = "staging-xcm"
-version = "16.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0126278d7fc6d7dec55e5a109f838bbf401dd084aecf2597e4e11ea07515a0a"
+version = "7.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
  "derive-where",
  "environmental",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
  "xcm-procedural",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f031952c1496cf7f86d19ab38e3264be9a54b7d8eecb25ba69f977cc7549d08"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "environmental",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-asset-conversion",
@@ -17488,11 +17488,11 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
  "staging-xcm",
  "staging-xcm-executor",
  "tracing",
@@ -17500,21 +17500,20 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9bc315e8c7018fcfe0371ce4b7e726fb699e37b2acc3e5effb87a7d131a3ff"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "environmental",
  "frame-benchmarking",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core 36.1.0",
- "sp-io 40.0.1",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
  "staging-xcm",
  "tracing",
 ]
@@ -17615,6 +17614,18 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
+version = "0.4.7"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2",
+ "schnorrkel 0.11.4",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "substrate-bip39"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
@@ -17642,14 +17653,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619d33f2bb5f1607f9073246163601c45f66044e85ade06bcb83feebf303ecd3"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17657,13 +17666,27 @@ dependencies = [
  "jsonrpsee 0.24.9",
  "log",
  "parity-scale-codec",
- "sc-rpc-api 0.48.0",
- "sc-transaction-pool-api 39.0.0",
- "sp-api 36.0.1",
- "sp-block-builder 36.0.0",
- "sp-blockchain 39.0.0",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
+ "sc-rpc-api 0.33.0",
+ "sc-transaction-pool-api 28.0.0",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
+dependencies = [
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "prometheus",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -17697,27 +17720,25 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282d436872be0350a4fc119f2c66c203ae13d2ed4d733bb6dcb4330475bbbb21"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
- "sc-client-api 39.0.0",
- "sc-rpc-api 0.48.0",
+ "sc-client-api 28.0.0",
+ "sc-rpc-api 0.33.0",
  "serde",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-state-machine 0.45.0",
- "sp-trie 39.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
  "trie-db 0.30.0",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc17ecd661e16b25708f36f6e6961f809a3ab16c89132a4acd7936c0f31e46"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -17725,9 +17746,9 @@ dependencies = [
  "filetime",
  "jobserver",
  "parity-wasm",
- "polkavm-linker 0.18.0",
+ "polkavm-linker 0.24.0",
  "shlex",
- "sp-maybe-compressed-blob",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.20",
@@ -17755,20 +17776,17 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c17d7ec2359d33133b63c97e28c8b7cd3f0a5bc6ce567ae3aef9d9e85be3433"
+checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
- "impl-serde 0.5.0",
- "jsonrpsee 0.24.9",
  "parity-scale-codec",
- "polkadot-sdk",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-decode",
@@ -17777,11 +17795,13 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
- "thiserror 1.0.69",
+ "subxt-rpcs",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -17791,9 +17811,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6550ef451c77db6e3bc7c56fb6fe1dca9398a2c8fc774b127f6a396a769b9c5b"
+checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -17803,26 +17823,25 @@ dependencies = [
  "scale-typegen",
  "subxt-metadata",
  "syn 2.0.100",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "subxt-core"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7a1bc6c9c1724971636a66e3225a7253cdb35bb6efb81524a6c71c04f08c59"
+checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
  "frame-decode",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde 0.5.0",
  "keccak-hash",
  "parity-scale-codec",
- "polkadot-sdk",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-decode",
@@ -17831,22 +17850,24 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ebc9131da4d0ba1f7814495b8cc79698798ccd52cacd7bcefe451e415bd945"
+checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
 dependencies = [
  "futures",
  "futures-util",
  "serde",
  "serde_json",
  "smoldot-light 0.16.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -17854,9 +17875,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7819c5e09aae0319981ee853869f2fcd1fac4db8babd0d004c17161297aadc05"
+checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -17870,23 +17891,47 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacd4e7484fef58deaa2dcb32d94753a864b208a668c0dd0c28be1d8abeeadb2"
+checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
  "frame-decode",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
- "polkadot-sdk",
  "scale-info",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+dependencies = [
+ "derive-where",
+ "frame-metadata 20.0.0",
+ "futures",
+ "hex",
+ "impl-serde 0.5.0",
+ "jsonrpsee 0.24.9",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-core",
+ "subxt-lightclient",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d680352d04665b1e4eb6f9d2a54b800c4d8e1b20478e69be1b7d975b08d9fc34"
+checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -17898,7 +17943,6 @@ dependencies = [
  "keccak-hash",
  "parity-scale-codec",
  "pbkdf2",
- "polkadot-sdk",
  "regex",
  "schnorrkel 0.11.4",
  "scrypt",
@@ -17907,19 +17951,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c53bc3eeaacc143a2f29ace4082edd2edaccab37b69ad20befba9fb00fdb3d"
+checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
 dependencies = [
  "hex",
  "parity-scale-codec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -17946,9 +17992,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.25"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -17977,6 +18023,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -18489,9 +18550,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a8f8a5b9157a1a473ffc8f2395b828a4238ed4b15044a9f861573f98049418"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18502,8 +18562,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f074568687ffdfd0adb6005aa8d1d96840197f2c159f80471285f08694cf0ce"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -18694,7 +18753,7 @@ dependencies = [
  "sp-consensus-aura 0.36.0",
  "sp-consensus-babe 0.36.0",
  "sp-core 32.0.0",
- "sp-debug-derive",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.28.0",
  "sp-inherents 30.0.0",
  "sp-io 34.0.0",
@@ -18705,7 +18764,7 @@ dependencies = [
  "sp-timestamp 30.0.0",
  "sp-transaction-storage-proof 30.0.0",
  "sp-version 33.0.0",
- "sp-weights",
+ "sp-weights 31.1.0",
  "substrate-rpc-client",
  "zstd 0.12.4",
 ]
@@ -19657,9 +19716,8 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime"
-version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34668cf57316a6ce10660730516985162f3538295fb5ff1cb8bf1b3067363952"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19667,11 +19725,11 @@ dependencies = [
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime 0.46.0",
+ "frame-try-runtime 0.34.0",
  "hex-literal",
  "log",
  "pallet-asset-rate",
@@ -19686,12 +19744,10 @@ dependencies = [
  "pallet-delegated-staking",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
- "pallet-elections-phragmen",
  "pallet-fast-unstake",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-indices",
- "pallet-membership",
  "pallet-message-queue",
  "pallet-meta-tx",
  "pallet-migrations",
@@ -19711,10 +19767,10 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
- "pallet-society",
  "pallet-staking",
+ "pallet-staking-async-ah-client",
+ "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -19735,28 +19791,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sp-api 36.0.1",
- "sp-application-crypto 40.1.0",
- "sp-arithmetic",
+ "sp-api 26.0.0",
+ "sp-application-crypto 30.0.0",
+ "sp-arithmetic 23.0.0",
  "sp-authority-discovery",
- "sp-block-builder 36.0.0",
- "sp-consensus-babe 0.42.1",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-babe 0.32.0",
  "sp-consensus-beefy",
- "sp-consensus-grandpa 23.1.0",
- "sp-core 36.1.0",
- "sp-genesis-builder 0.17.0",
- "sp-inherents 36.0.0",
- "sp-io 40.0.1",
- "sp-keyring 41.0.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-io 30.0.0",
+ "sp-keyring 31.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
- "sp-offchain 36.0.0",
- "sp-runtime 41.1.0",
- "sp-session 38.1.0",
- "sp-staking 38.0.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 36.0.0",
- "sp-version 39.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -19767,17 +19823,16 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353ec9fb34d2bea0e0dcf9132b47926eb3afcdacc52e3d75ffcf95c858d29c9d"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 36.1.0",
- "sp-runtime 41.1.0",
- "sp-weights",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -19843,6 +19898,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
@@ -19871,6 +19936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -20326,9 +20400,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "11.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3d21c65cbf847ae0b1a8e6411b614d269d3108c6c649b039bffcf225e89aa4"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20338,15 +20411,14 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87c89a2721a4423325f21453ff71bb7a874cfdbe31a25d70d571804b68c0e06"
+version = "0.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#3ff2859d78e2a4a7ff9afe855f7863e4ef650068"
 dependencies = [
- "frame-support 40.1.0",
+ "frame-support 28.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api 36.0.1",
- "sp-weights",
+ "sp-api 26.0.0",
+ "sp-weights 27.0.0",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -20413,9 +20485,9 @@ dependencies = [
 
 [[package]]
 name = "yap"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4524214bc4629eba08d78ceb1d6507070cc0bcbbed23af74e19e6e924a24cf"
+checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,15 +1720,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.3",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2148,6 +2147,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,7 +2500,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-client-api 39.0.0",
  "sc-consensus 0.48.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-sync 0.48.0",
  "sc-network-transactions 0.48.0",
  "sc-rpc 44.0.0",
@@ -2499,7 +2513,7 @@ dependencies = [
  "sp-blockchain 39.0.0",
  "sp-consensus 0.42.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-transaction-pool 36.0.0",
 ]
@@ -2535,7 +2549,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
 ]
@@ -2565,7 +2579,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-externalities 0.30.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-std",
@@ -2613,7 +2627,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
 ]
@@ -2637,7 +2651,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2792,7 +2806,7 @@ dependencies = [
  "polkadot-service",
  "sc-authority-discovery",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-service 0.50.0",
  "sc-tracing 39.0.0",
@@ -3937,12 +3951,12 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.0.0"
+version = "40.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b0892434d3cc61fab58b2e48b27b12fc162465c5af48fa283ed15bb86dbfb2"
+checksum = "4a9e5fcdb30bb83b2d97d7e718127230e0fbbad82b9c32dedf63971f08709def"
 dependencies = [
  "frame-support 40.1.0",
- "frame-support-procedural 33.0.0",
+ "frame-support-procedural 33.0.1",
  "frame-system",
  "linregress",
  "log",
@@ -3953,7 +3967,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-runtime-interface 29.0.1",
  "sp-storage 22.0.0",
@@ -3962,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.0.0"
+version = "47.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873cb5fd4e7f94dbb80561e29c20da73da20f74f8dc35809fbb0e2a5d35ed7b0"
+checksum = "c43e7d09632b60f261e94854bdce91fd731a692b74b37e54e1a6e99a317a28d0"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4005,7 +4019,7 @@ dependencies = [
  "sp-externalities 0.30.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
@@ -4066,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f15cc5de17ca5665e65e8436a6faf816a2807e1bfe573fb9edcf1a81837d23"
+checksum = "0cc32bb3f500bb1b4661ad73bc270890178f067af38ed7e4ab2c85d03b18b0f8"
 dependencies = [
  "aquamarine",
  "frame-support 40.1.0",
@@ -4078,7 +4092,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
 ]
@@ -4214,7 +4228,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata 20.0.0",
- "frame-support-procedural 33.0.0",
+ "frame-support-procedural 33.0.1",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -4231,7 +4245,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-metadata-ir 0.10.0",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -4265,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.0"
+version = "33.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bc18090aa96a5e69cd566fb755b5be08964b926864b2101dd900f64a870437"
+checksum = "bcb3c16c8fe1b4edc6df122212b50f776dfce31a94fa63305100841ba4eb7c93"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4335,7 +4349,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-version 39.0.0",
  "sp-weights",
@@ -4590,6 +4604,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -4941,6 +4969,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.1",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 1.0.3",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.1",
+ "ring 0.17.14",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4948,7 +5001,7 @@ checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "ipconfig",
  "lru-cache",
  "once_cell",
@@ -4957,6 +5010,27 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand 0.9.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -5099,6 +5173,16 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -5416,7 +5500,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows",
+ "windows 0.53.0",
 ]
 
 [[package]]
@@ -5601,7 +5685,7 @@ dependencies = [
  "sc-consensus-grandpa",
  "sc-consensus-manual-seal",
  "sc-executor 0.42.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-sync 0.48.0",
  "sc-offchain",
  "sc-rpc 44.0.0",
@@ -5619,7 +5703,7 @@ dependencies = [
  "sp-consensus-aura 0.42.0",
  "sp-consensus-grandpa 23.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
@@ -6546,7 +6630,7 @@ checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.24.4",
  "libp2p-core 0.42.0",
  "libp2p-identity 0.2.10",
  "parking_lot 0.12.3",
@@ -6721,7 +6805,7 @@ checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
 dependencies = [
  "data-encoding",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "if-watch",
  "libp2p-core 0.42.0",
  "libp2p-identity 0.2.10",
@@ -7166,7 +7250,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.4",
+ "yamux 0.13.5",
 ]
 
 [[package]]
@@ -7331,19 +7415,18 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3aa5628ae2b2283aa01dfa58947f1926aedba0160dd25041e2cd4bc71534c9"
+checksum = "14fb10e63363204b89d91e1292df83322fd9de5d7fa76c3d5c78ddc2f8f3efa9"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hex-literal",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "indexmap 2.9.0",
  "libc",
  "mockall 0.13.1",
@@ -7352,12 +7435,9 @@ dependencies = [
  "network-interface",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
  "prost-build 0.13.5",
  "rand 0.8.5",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
  "serde",
  "sha2 0.10.8",
  "simple-dns",
@@ -7375,7 +7455,7 @@ dependencies = [
  "url",
  "x25519-dalek 2.0.1",
  "x509-parser 0.17.0",
- "yamux 0.13.4",
+ "yamux 0.13.5",
  "yasna",
  "zeroize",
 ]
@@ -7395,6 +7475,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.19",
+]
 
 [[package]]
 name = "lru"
@@ -7760,6 +7853,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version 0.4.1",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "multi-stash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7819,23 +7931,6 @@ name = "multihash"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -8008,9 +8103,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "c3329f515506e4a2de3aa6e07027a6758e22e0f0e8eaf64fa47261cec2282602"
 dependencies = [
  "cc",
  "libc",
@@ -8248,6 +8343,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -8327,7 +8426,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8358,7 +8457,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8444,7 +8543,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-consensus-babe 0.42.1",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session 38.1.0",
  "sp-staking 38.0.0",
@@ -8467,7 +8566,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
 ]
@@ -8530,7 +8629,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-consensus-beefy",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
 ]
@@ -8549,7 +8648,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8587,7 +8686,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8624,7 +8723,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8639,7 +8738,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8658,7 +8757,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8679,7 +8778,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-npos-elections",
  "sp-runtime 41.1.0",
  "strum 0.26.3",
@@ -8712,7 +8811,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-npos-elections",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -8732,7 +8831,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8754,7 +8853,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-consensus-grandpa 23.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session 38.1.0",
  "sp-staking 38.0.0",
@@ -8773,7 +8872,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8792,7 +8891,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8809,7 +8908,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8838,7 +8937,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8857,7 +8956,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
 ]
@@ -8876,7 +8975,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
 ]
@@ -8897,7 +8996,7 @@ dependencies = [
  "polkadot-sdk-frame",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8950,7 +9049,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
  "sp-tracing",
@@ -9059,7 +9158,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9089,7 +9188,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9104,7 +9203,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9123,15 +9222,15 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
 [[package]]
 name = "pallet-revive"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895fe6f50f621a69132697b8b43d29d1db4d9ff445eec410bf1fc98cd7e9412c"
+checksum = "0ff67ac7b1053411a2bd2f5438cc0fa0c58757ec0c51efa551f1cfcd9ebc7ee3"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.19",
@@ -9142,6 +9241,7 @@ dependencies = [
  "frame-support 40.1.0",
  "frame-system",
  "hex-literal",
+ "humantime-serde",
  "impl-trait-for-tuples",
  "log",
  "num-bigint",
@@ -9166,7 +9266,7 @@ dependencies = [
  "sp-consensus-babe 0.42.1",
  "sp-consensus-slots 0.42.1",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9185,7 +9285,7 @@ dependencies = [
  "pallet-revive-uapi",
  "polkavm-linker 0.21.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "toml 0.8.20",
 ]
 
@@ -9224,7 +9324,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9241,16 +9341,16 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957973f62a34695f5b6e17b33ad67a11c8310fe9e16c898769c047add6b34c22"
+checksum = "35361f753986d6fe6654b3e5d283700c4f0bb082221c6aaf299912a29679c880"
 dependencies = [
  "frame-support 40.1.0",
  "frame-system",
@@ -9260,7 +9360,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session 38.1.0",
  "sp-staking 38.0.0",
@@ -9299,7 +9399,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9321,7 +9421,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto 40.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -9360,7 +9460,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9376,7 +9476,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9394,7 +9494,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-storage 22.0.0",
  "sp-timestamp 36.0.0",
@@ -9415,7 +9515,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9432,7 +9532,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9498,7 +9598,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9514,7 +9614,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
 ]
@@ -9547,9 +9647,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "19.1.0"
+version = "19.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7e7cc378044212673fa3d477324504642178fa9f98d96e56981fb57bbbe3e1"
+checksum = "ca27d506282f4c9cd2cac6fb0d199edd89d366635f04801319e7145912547a68"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9560,7 +9660,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9580,7 +9680,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9610,7 +9710,7 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura 0.42.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-parachain-info",
  "staging-xcm",
@@ -9992,7 +10092,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "schnellru",
  "sp-core 36.1.0",
  "sp-keystore 0.42.0",
@@ -10017,7 +10117,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "schnellru",
  "thiserror 1.0.69",
  "tokio",
@@ -10111,7 +10211,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sp-application-crypto 40.1.0",
  "sp-keystore 0.42.0",
  "thiserror 1.0.69",
@@ -10147,7 +10247,7 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
@@ -10173,7 +10273,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sp-consensus 0.42.0",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -10503,7 +10603,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-crypto-hashing",
  "sp-externalities 0.30.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-tracing",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -10561,7 +10661,7 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "sc-authority-discovery",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sp-runtime 41.1.0",
  "strum 0.26.3",
@@ -10620,7 +10720,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sc-transaction-pool-api 39.0.0",
  "smallvec",
@@ -10724,7 +10824,7 @@ dependencies = [
  "sp-consensus-slots 0.42.1",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -10805,7 +10905,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-npos-elections",
  "sp-runtime 41.1.0",
@@ -10867,7 +10967,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
  "sp-session 38.1.0",
@@ -10913,7 +11013,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-offchain 36.0.0",
  "sp-runtime 41.1.0",
@@ -10994,7 +11094,7 @@ dependencies = [
  "sc-consensus-slots",
  "sc-executor 0.42.0",
  "sc-keystore 35.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-sync 0.48.0",
  "sc-offchain",
  "sc-service 0.50.0",
@@ -11016,7 +11116,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-mmr-primitives",
  "sp-offchain 36.0.0",
@@ -12406,7 +12506,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-mmr-primitives",
  "sp-offchain 36.0.0",
@@ -12952,7 +13052,7 @@ dependencies = [
  "prost-build 0.13.5",
  "rand 0.8.5",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sp-api 36.0.1",
  "sp-authority-discovery",
@@ -13058,7 +13158,7 @@ dependencies = [
  "sc-chain-spec-derive 12.0.0",
  "sc-client-api 39.0.0",
  "sc-executor 0.42.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-telemetry 28.1.0",
  "serde",
  "serde_json",
@@ -13066,7 +13166,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-crypto-hashing",
  "sp-genesis-builder 0.17.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-tracing",
@@ -13162,7 +13262,7 @@ dependencies = [
  "sc-client-db 0.46.0",
  "sc-keystore 35.0.0",
  "sc-mixnet 0.19.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-service 0.50.0",
  "sc-telemetry 28.1.0",
  "sc-tracing 39.0.0",
@@ -13445,7 +13545,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "sc-client-api 39.0.0",
  "sc-consensus 0.48.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-gossip",
  "sc-network-sync 0.48.0",
  "sc-network-types",
@@ -13522,7 +13622,7 @@ dependencies = [
  "sc-chain-spec 42.0.0",
  "sc-client-api 39.0.0",
  "sc-consensus 0.48.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-network-gossip",
  "sc-network-sync 0.48.0",
@@ -13665,7 +13765,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-core 36.1.0",
  "sp-externalities 0.30.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-panic-handler",
  "sp-runtime-interface 29.0.1",
  "sp-trie 39.1.0",
@@ -13791,7 +13891,7 @@ dependencies = [
  "futures-timer",
  "log",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-sync 0.48.0",
  "sp-blockchain 39.0.0",
  "sp-runtime 41.1.0",
@@ -13874,7 +13974,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sc-transaction-pool-api 39.0.0",
  "sp-api 36.0.1",
@@ -13932,9 +14032,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4601296dddbaee7cb7eaf5709bbd24a56bba470d8b8cbadaad77496fe70a7706"
+checksum = "df65eb7a3c4c141de3f14b12a9832c75c7ada1fd580b0bc440263cb8ca2c5b77"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14041,7 +14141,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "log",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-network-sync 0.48.0",
  "sc-network-types",
@@ -14087,7 +14187,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.13.5",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sp-blockchain 39.0.0",
  "sp-core 36.1.0",
@@ -14150,7 +14250,7 @@ dependencies = [
  "prost-build 0.13.5",
  "sc-client-api 39.0.0",
  "sc-consensus 0.48.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-network-types",
  "sc-utils 18.0.1",
@@ -14198,7 +14298,7 @@ dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-network-sync 0.48.0",
  "sc-network-types",
@@ -14249,7 +14349,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.23.26",
  "sc-client-api 39.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-types",
  "sc-transaction-pool-api 39.0.0",
  "sc-utils 18.0.1",
@@ -14595,7 +14695,7 @@ dependencies = [
  "sc-executor 0.42.0",
  "sc-informant 0.48.0",
  "sc-keystore 35.0.0",
- "sc-network 0.49.0",
+ "sc-network 0.49.1",
  "sc-network-common 0.48.0",
  "sc-network-light 0.48.0",
  "sc-network-sync 0.48.0",
@@ -14734,7 +14834,7 @@ dependencies = [
  "serde_json",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
 ]
 
 [[package]]
@@ -15166,6 +15266,12 @@ dependencies = [
  "subtle 2.6.1",
  "zeroize",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -16020,7 +16126,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
 ]
 
 [[package]]
@@ -16228,7 +16334,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-mmr-primitives",
  "sp-runtime 41.1.0",
@@ -16540,9 +16646,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
+checksum = "3e41d010bcc515d119901ff7ac83150c335d543c7f6c03be5c8fe08430b8a03b"
 dependencies = [
  "bytes",
  "docify",
@@ -16800,7 +16906,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-std",
  "sp-trie 39.1.0",
  "sp-weights",
@@ -17347,9 +17453,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "16.1.0"
+version = "16.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead7481ba2dec11b0df89745cef3a76f3eef9c9df20155426cd7e9651b4c799"
+checksum = "d0126278d7fc6d7dec55e5a109f838bbf401dd084aecf2597e4e11ea07515a0a"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -17369,9 +17475,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.0.0"
+version = "20.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041eaa60fc0df3dbaa5779959f5eaac9c1b81d045a5a1792479e46dfd31f028"
+checksum = "6f031952c1496cf7f86d19ab38e3264be9a54b7d8eecb25ba69f977cc7549d08"
 dependencies = [
  "environmental",
  "frame-support 40.1.0",
@@ -17384,7 +17490,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm",
@@ -17394,9 +17500,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.0"
+version = "19.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6d7cc19f02e4c088c2719fe11f22216041909d6a6ab130c71e8d25818d7768"
+checksum = "af9bc315e8c7018fcfe0371ce4b7e726fb699e37b2acc3e5effb87a7d131a3ff"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17406,7 +17512,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm",
@@ -17609,9 +17715,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681dd525b728263041cde9acdd07fa1c4d9f184c9b269a1c9df26e8401dae67"
+checksum = "1adc17ecd661e16b25708f36f6e6961f809a3ab16c89132a4acd7936c0f31e46"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -17895,6 +18001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18117,9 +18229,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -18216,9 +18328,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -18807,6 +18919,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -19623,7 +19746,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring 41.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
@@ -19729,6 +19852,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19749,6 +19894,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -19778,6 +19933,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -20173,9 +20338,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c167c669dcff79985e7367c70a8adeba6021b156c710133615c1183a31a5895"
+checksum = "b87c89a2721a4423325f21453ff71bb7a874cfdbe31a25d70d571804b68c0e06"
 dependencies = [
  "frame-support 40.1.0",
  "parity-scale-codec",
@@ -20232,16 +20397,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.1",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ panic = 'unwind'
 
 [workspace.dependencies]
 clap = { version = "4.5.13", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = [
   "derive",
 ] }
 futures = "0.3.31"
@@ -32,111 +32,111 @@ color-print = "0.3.4"
 wasmtime = "8.0.1"
 
 # Substrate
-frame-benchmarking = { version = "40.2.0", default-features = false }
-frame-benchmarking-cli = { version = "47.2.0" }
-frame-executive = { version = "40.0.1", default-features = false }
-frame-support = { version = "40.1.0", default-features = false }
-frame-support-procedural = { version = "33.0.1", default-features = false }
-frame-system = { version = "40.1.0", default-features = false }
-frame-system-benchmarking = { version = "40.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "36.0.0", default-features = false }
-frame-try-runtime = { version = "0.46.0", default-features = false }
-pallet-aura = { version = "39.0.0", default-features = false }
-pallet-authorship = { version = "40.0.0", default-features = false }
-pallet-balances = { version = "41.1.0", default-features = false }
-pallet-session = { version = "40.0.1", default-features = false }
-pallet-sudo = { version = "40.0.0", default-features = false }
-pallet-timestamp = { version = "39.0.0", default-features = false }
-pallet-transaction-payment = { version = "40.0.0", default-features = false }
-pallet-message-queue = { version = "43.1.0", default-features = false }
-pallet-transaction-payment-rpc = { version = "43.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { version = "40.0.0", default-features = false }
-sc-basic-authorship = { version = "0.49.0" }
-sc-chain-spec = { version = "42.0.0" }
-sc-cli = { version = "0.51.0" }
-sc-client-api = { version = "39.0.0" }
-sc-consensus = { version = "0.48.0" }
-sc-executor = { version = "0.42.0" }
-sc-network = { version = "0.49.1" }
-sc-network-sync = { version = "0.48.0" }
-sc-offchain = { version = "44.0.0" }
-sc-rpc = { version = "44.0.0" }
-sc-service = { version = "0.50.0" }
-sc-sysinfo = { version = "42.0.0" }
-sc-telemetry = { version = "28.1.0" }
-sc-tracing = { version = "39.0.0" }
-sc-transaction-pool = { version = "39.0.0" }
-sc-transaction-pool-api = { version = "39.0.0" }
-sp-api = { version = "36.0.1", default-features = false }
-sp-keyring = { version = "41.0.0", default-features = false }
-sp-block-builder = { version = "36.0.0", default-features = false }
-sp-blockchain = { version = "39.0.0" }
-sp-consensus-aura = { version = "0.42.0", default-features = false }
-sp-core = { version = "36.1.0", default-features = false }
-sp-inherents = { version = "36.0.0", default-features = false }
-sp-io = { version = "40.0.1", default-features = false }
-sp-keystore = { version = "0.42.0" }
-sp-offchain = { version = "36.0.0", default-features = false }
-sp-runtime = { version = "41.1.0", default-features = false }
-sp-session = { version = "38.1.0", default-features = false }
-sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = { version = "36.0.0" }
-sp-transaction-pool = { version = "36.0.0", default-features = false }
-sp-version = { version = "39.0.0", default-features = false }
-substrate-frame-rpc-system = { version = "43.0.0" }
-prometheus-endpoint = { version = "0.17.2", package = "substrate-prometheus-endpoint", default-features = false }
-substrate-wasm-builder = { version = "26.0.1" }
-substrate-build-script-utils = { version = "11.0.0" }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-support-procedural = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", package = "substrate-prometheus-endpoint", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
 try-runtime-cli = { version = "0.42.0" }
 
 # extra deps for running a solo node on top of a parachain
-pallet-grandpa = { version = "40.0.0", default-features = false }
-sc-consensus-grandpa = { version = "0.34.0", default-features = false }
-sp-consensus-grandpa = { version = "23.1.0", default-features = false }
-sp-genesis-builder = { version = "0.17.0", default-features = false }
-sp-storage = { version = "22.0.0", default-features = false }
-sc-consensus-aura = { version = "0.49.0", default-features = false }
-sc-consensus-manual-seal = { version = "0.50.0", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 
 # extra deps for setting up pallet-revive
-pallet-assets = { version = "42.0.0", default-features = false }
-pallet-insecure-randomness-collective-flip = { version = "28.0.0", default-features = false }
-pallet-revive = { version = "0.6.1", default-features = false }
-pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["scale", "$unstable-hostfn"] }
-pallet-utility = { version = "40.0.0", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false, features = ["scale", "$unstable-hostfn"] }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "19.1.2", default-features = false }
-polkadot-cli = { version = "23.0.0", default-features = false }
-polkadot-parachain-primitives = { version = "16.1.0", default-features = false }
-polkadot-primitives = { version = "18.1.0" }
-polkadot-runtime-common = { version = "19.1.0", default-features = false }
-xcm = { version = "16.2.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "20.1.1", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "19.1.2", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", package = "staging-xcm", default-features = false }
+xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = { version = "0.22.0" }
-cumulus-client-collator = { version = "0.22.0" }
-cumulus-client-consensus-proposer = { version = "0.19.0" }
-cumulus-client-consensus-aura = { version = "0.22.0" }
-cumulus-client-consensus-common = { version = "0.22.0" }
-cumulus-client-service = { version = "0.23.0" }
-cumulus-pallet-aura-ext = { version = "0.20.0", default-features = false }
-cumulus-pallet-dmp-queue = { version = "0.20.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.20.0", default-features = false }
-cumulus-pallet-session-benchmarking = { version = "21.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.19.1", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.20.0", default-features = false }
-cumulus-primitives-aura = { version = "0.17.0", default-features = false }
-cumulus-primitives-core = { version = "0.18.1", default-features = false }
-cumulus-primitives-parachain-inherent = { version = "0.18.1" }
-cumulus-primitives-timestamp = { version = "0.19.0", default-features = false }
-cumulus-primitives-utility = { version = "0.20.0", default-features = false }
-cumulus-relay-chain-interface = { version = "0.22.0" }
-pallet-collator-selection = { version = "21.0.0", default-features = false }
-parachain-info = { version = "0.20.0", package = "staging-parachain-info", default-features = false }
-parachains-common = { version = "21.0.0", default-features = false }
+cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-client-consensus-proposer ={ git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-client-consensus-common ={ git = "https://github.com/paritytech/polkadot-sdk", branch = "master" } 
+cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+pallet-collator-selection = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", package = "staging-parachain-info", default-features = false }
+parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 
 # todo Pin until https://github.com/jhpratt/deranged/issues/18 is resolved
 deranged = { version = "=0.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ color-print = "0.3.4"
 wasmtime = "8.0.1"
 
 # Substrate
-frame-benchmarking = { version = "40.0.0", default-features = false }
-frame-benchmarking-cli = { version = "47.0.0" }
-frame-executive = { version = "40.0.0", default-features = false }
+frame-benchmarking = { version = "40.2.0", default-features = false }
+frame-benchmarking-cli = { version = "47.2.0" }
+frame-executive = { version = "40.0.1", default-features = false }
 frame-support = { version = "40.1.0", default-features = false }
-frame-support-procedural = { version = "33.0.0", default-features = false }
+frame-support-procedural = { version = "33.0.1", default-features = false }
 frame-system = { version = "40.1.0", default-features = false }
 frame-system-benchmarking = { version = "40.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "36.0.0", default-features = false }
@@ -44,7 +44,7 @@ frame-try-runtime = { version = "0.46.0", default-features = false }
 pallet-aura = { version = "39.0.0", default-features = false }
 pallet-authorship = { version = "40.0.0", default-features = false }
 pallet-balances = { version = "41.1.0", default-features = false }
-pallet-session = { version = "40.0.0", default-features = false }
+pallet-session = { version = "40.0.1", default-features = false }
 pallet-sudo = { version = "40.0.0", default-features = false }
 pallet-timestamp = { version = "39.0.0", default-features = false }
 pallet-transaction-payment = { version = "40.0.0", default-features = false }
@@ -57,7 +57,7 @@ sc-cli = { version = "0.51.0" }
 sc-client-api = { version = "39.0.0" }
 sc-consensus = { version = "0.48.0" }
 sc-executor = { version = "0.42.0" }
-sc-network = { version = "0.49.0" }
+sc-network = { version = "0.49.1" }
 sc-network-sync = { version = "0.48.0" }
 sc-offchain = { version = "44.0.0" }
 sc-rpc = { version = "44.0.0" }
@@ -74,7 +74,7 @@ sp-blockchain = { version = "39.0.0" }
 sp-consensus-aura = { version = "0.42.0", default-features = false }
 sp-core = { version = "36.1.0", default-features = false }
 sp-inherents = { version = "36.0.0", default-features = false }
-sp-io = { version = "40.0.0", default-features = false }
+sp-io = { version = "40.0.1", default-features = false }
 sp-keystore = { version = "0.42.0" }
 sp-offchain = { version = "36.0.0", default-features = false }
 sp-runtime = { version = "41.1.0", default-features = false }
@@ -85,7 +85,7 @@ sp-transaction-pool = { version = "36.0.0", default-features = false }
 sp-version = { version = "39.0.0", default-features = false }
 substrate-frame-rpc-system = { version = "43.0.0" }
 prometheus-endpoint = { version = "0.17.2", package = "substrate-prometheus-endpoint", default-features = false }
-substrate-wasm-builder = { version = "26.0.0" }
+substrate-wasm-builder = { version = "26.0.1" }
 substrate-build-script-utils = { version = "11.0.0" }
 try-runtime-cli = { version = "0.42.0" }
 
@@ -101,19 +101,19 @@ sc-consensus-manual-seal = { version = "0.50.0", default-features = false }
 # extra deps for setting up pallet-revive
 pallet-assets = { version = "42.0.0", default-features = false }
 pallet-insecure-randomness-collective-flip = { version = "28.0.0", default-features = false }
-pallet-revive = { version = "0.5.0", default-features = false }
+pallet-revive = { version = "0.6.1", default-features = false }
 pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["scale", "$unstable-hostfn"] }
 pallet-utility = { version = "40.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "19.1.0", default-features = false }
+pallet-xcm = { version = "19.1.2", default-features = false }
 polkadot-cli = { version = "23.0.0", default-features = false }
 polkadot-parachain-primitives = { version = "16.1.0", default-features = false }
 polkadot-primitives = { version = "18.1.0" }
 polkadot-runtime-common = { version = "19.1.0", default-features = false }
-xcm = { version = "16.1.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "20.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "19.1.0", package = "staging-xcm-executor", default-features = false }
+xcm = { version = "16.2.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "20.1.1", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "19.1.2", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
 cumulus-client-cli = { version = "0.22.0" }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -249,7 +249,7 @@ pub async fn start_parachain_node(
 	let backend = params.backend.clone();
 	let mut task_manager = params.task_manager;
 
-	let (relay_chain_interface, collator_key) = build_relay_chain_interface(
+	let (relay_chain_interface, collator_key, _, _) = build_relay_chain_interface(
 		polkadot_config,
 		&parachain_config,
 		telemetry_worker_handle,
@@ -381,6 +381,7 @@ pub async fn start_parachain_node(
 		relay_chain_slot_duration,
 		recovery_handle: Box::new(overseer_handle.clone()),
 		sync_service: sync_service.clone(),
+		prometheus_registry: prometheus_registry.as_ref(),
 	})?;
 
 	if validator {

--- a/parachain-runtime/src/lib.rs
+++ b/parachain-runtime/src/lib.rs
@@ -417,6 +417,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
+	type RelayParentOffset = ConstU32<0>;
 }
 
 impl parachain_info::Config for Runtime {}
@@ -888,7 +889,7 @@ impl_runtime_apis! {
 				)
 			};
 
-			Revive::bare_eth_transact(tx, blockweights.max_block, tx_fee)
+			Revive::dry_run_eth_transact(tx, blockweights.max_block, tx_fee)
 		}
 
 		fn call(
@@ -948,6 +949,16 @@ impl_runtime_apis! {
 			key: [u8; 32],
 		) -> pallet_revive::GetStorageResult {
 			Revive::get_storage(
+				address,
+				key
+			)
+		}
+
+		fn get_storage_var_key(
+			address: H160,
+			key: Vec<u8>,
+		) -> pallet_revive::GetStorageResult {
+			Revive::get_storage_var_key(
 				address,
 				key
 			)

--- a/parachain-runtime/src/lib.rs
+++ b/parachain-runtime/src/lib.rs
@@ -955,20 +955,20 @@ impl_runtime_apis! {
 
 		fn trace_block(
 			block: Block,
-			config: pallet_revive::evm::TracerConfig
-		) -> Vec<(u32, pallet_revive::evm::CallTrace)> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Vec<(u32, pallet_revive::evm::Trace)> {
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let mut traces = vec![];
 			let (header, extrinsics) = block.deconstruct();
 
 			Executive::initialize_block(&header);
 			for (index, ext) in extrinsics.into_iter().enumerate() {
-				trace(&mut tracer, || {
+				trace(tracer.as_tracing(), || {
 					let _ = Executive::apply_extrinsic(ext);
 				});
 
-				if let Some(tx_trace) = tracer.collect_traces().pop() {
+				if let Some(tx_trace) = tracer.collect_trace() {
 					traces.push((index as u32, tx_trace));
 				}
 			}
@@ -979,16 +979,16 @@ impl_runtime_apis! {
 		fn trace_tx(
 			block: Block,
 			tx_index: u32,
-			config: pallet_revive::evm::TracerConfig
-		) -> Option<pallet_revive::evm::CallTrace> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Option<pallet_revive::evm::Trace> {
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let (header, extrinsics) = block.deconstruct();
 
 			Executive::initialize_block(&header);
 			for (index, ext) in extrinsics.into_iter().enumerate() {
 				if index as u32 == tx_index {
-					trace(&mut tracer, || {
+					trace(tracer.as_tracing(), || {
 						let _ = Executive::apply_extrinsic(ext);
 					});
 					break;
@@ -997,21 +997,21 @@ impl_runtime_apis! {
 				}
 			}
 
-			tracer.collect_traces().pop()
+			tracer.collect_trace()
 		}
 
 		fn trace_call(
 			tx: pallet_revive::evm::GenericTransaction,
-			config: pallet_revive::evm::TracerConfig)
-			-> Result<pallet_revive::evm::CallTrace, pallet_revive::EthTransactError>
+			tracer_type: pallet_revive::evm::TracerType)
+			-> Result<pallet_revive::evm::Trace, pallet_revive::EthTransactError>
 		{
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
-			trace(&mut tracer, || {
+			let mut tracer = Revive::evm_tracer(tracer_type);
+			trace(tracer.as_tracing(), || {
 				Self::eth_transact(tx)
 			})?;
 
-			Ok(tracer.collect_traces().pop().expect("eth_transact succeeded, trace must exist, qed"))
+			Ok(tracer.collect_trace().expect("eth_transact succeeded, trace must exist, qed"))
 		}
 	}
 

--- a/parachain-runtime/src/revive_config.rs
+++ b/parachain-runtime/src/revive_config.rs
@@ -1,13 +1,11 @@
 use crate::{
-	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeHoldReason, Timestamp,
+	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, Timestamp,
 };
 use frame_support::{
 	parameter_types,
 	traits::{ConstBool, ConstU32, ConstU64},
 };
 use frame_system::EnsureSigned;
-
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;

--- a/parachain-runtime/src/revive_config.rs
+++ b/parachain-runtime/src/revive_config.rs
@@ -1,5 +1,5 @@
 use crate::{
-	Balance, Balances, BalancesCall, Perbill, Runtime, RuntimeCall, RuntimeEvent,
+	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent,
 	RuntimeHoldReason, Timestamp,
 };
 use frame_support::{
@@ -8,13 +8,6 @@ use frame_support::{
 };
 use frame_system::EnsureSigned;
 
-pub enum AllowBalancesCall {}
-
-impl frame_support::traits::Contains<RuntimeCall> for AllowBalancesCall {
-	fn contains(call: &RuntimeCall) -> bool {
-		matches!(call, RuntimeCall::Balances(BalancesCall::transfer_allow_death { .. }))
-	}
-}
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;
@@ -37,28 +30,17 @@ impl pallet_revive::Config for Runtime {
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	/// The safest default is to allow no calls at all.
-	///
-	/// Runtimes should whitelist dispatchables that are allowed to be called from contracts
-	/// and make sure they are stable. Dispatchables exposed to contracts are not allowed to
-	/// change because that would break already deployed contracts. The `RuntimeCall` structure
-	/// itself is not allowed to change the indices of existing pallets, too.
-	type CallFilter = AllowBalancesCall;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
-	type ChainExtension = ();
+	type Precompiles = ();
 	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type UnsafeUnstableInterface = ConstBool<true>;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	#[cfg(feature = "parachain")]
-	type Xcm = pallet_xcm::Pallet<Self>;
-	#[cfg(not(feature = "parachain"))]
-	type Xcm = ();
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
 	type ChainId = ConstU64<420_420_420>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -598,20 +598,20 @@ impl_runtime_apis! {
 
 		fn trace_block(
 			block: Block,
-			config: pallet_revive::evm::TracerConfig
-		) -> Vec<(u32, pallet_revive::evm::CallTrace)> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Vec<(u32, pallet_revive::evm::Trace)> {
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let mut traces = vec![];
 			let (header, extrinsics) = block.deconstruct();
 
 			Executive::initialize_block(&header);
 			for (index, ext) in extrinsics.into_iter().enumerate() {
-				trace(&mut tracer, || {
+				trace(tracer.as_tracing(), || {
 					let _ = Executive::apply_extrinsic(ext);
 				});
 
-				if let Some(tx_trace) = tracer.collect_traces().pop() {
+				if let Some(tx_trace) = tracer.collect_trace() {
 					traces.push((index as u32, tx_trace));
 				}
 			}
@@ -622,11 +622,11 @@ impl_runtime_apis! {
 		fn trace_tx(
 			block: Block,
 			tx_index: u32,
-			config: pallet_revive::evm::TracerConfig
-		) -> Option<pallet_revive::evm::CallTrace> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Option<pallet_revive::evm::Trace> {
 			log::info!("-----trace_tx called with tx_index {:?}", tx_index);
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let (header, extrinsics) = block.deconstruct();
 
 			log::info!("-----trace_tx found {:?} xts", extrinsics.len());
@@ -636,7 +636,7 @@ impl_runtime_apis! {
 				log::info!("-----trace_tx enumerating {:?}", index);
 				if index as u32 == tx_index {
 					log::info!("-----trace_tx found tx_index {:?}", tx_index);
-					trace(&mut tracer, || {
+					trace(tracer.as_tracing(), || {
 						log::info!("-----trace_tx applying extrinsic");
 						let res = Executive::apply_extrinsic(ext);
 						log::info!("-----trace_tx after applying extrinsic {:?}", res);
@@ -650,29 +650,23 @@ impl_runtime_apis! {
 				}
 			}
 			log::info!("-----trace_tx after loop");
-
-			let mut traces = tracer.collect_traces();
-			log::info!("-----trace_tx traces.len() {:?}", traces.len());
-			log::info!("-----trace_tx traces {:?}", traces);
-
-			let traces = traces.pop();
-			log::info!("-----trace_tx traces popped {:?}", traces);
-
-			traces
+			let trace = tracer.collect_trace();
+			log::info!("-----trace_tx trace {:?}", trace);
+			trace
 		}
 
 		fn trace_call(
 			tx: pallet_revive::evm::GenericTransaction,
-			config: pallet_revive::evm::TracerConfig)
-			-> Result<pallet_revive::evm::CallTrace, pallet_revive::EthTransactError>
+			tracer_type: pallet_revive::evm::TracerType)
+			-> Result<pallet_revive::evm::Trace, pallet_revive::EthTransactError>
 		{
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
-			trace(&mut tracer, || {
+			let mut tracer = Revive::evm_tracer(tracer_type);
+			trace(tracer.as_tracing(), || {
 				Self::eth_transact(tx)
 			})?;
 
-			Ok(tracer.collect_traces().pop().expect("eth_transact succeeded, trace must exist, qed"))
+			Ok(tracer.collect_trace().expect("eth_transact succeeded, trace must exist, qed"))
 		}
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -531,7 +531,7 @@ impl_runtime_apis! {
 				)
 			};
 
-			Revive::bare_eth_transact(tx, blockweights.max_block, tx_fee)
+			Revive::dry_run_eth_transact(tx, blockweights.max_block, tx_fee)
 		}
 
 		fn call(
@@ -591,6 +591,16 @@ impl_runtime_apis! {
 			key: [u8; 32],
 		) -> pallet_revive::GetStorageResult {
 			Revive::get_storage(
+				address,
+				key
+			)
+		}
+
+		fn get_storage_var_key(
+			address: H160,
+			key: Vec<u8>,
+		) -> pallet_revive::GetStorageResult {
+			Revive::get_storage_var_key(
 				address,
 				key
 			)

--- a/runtime/src/revive_config.rs
+++ b/runtime/src/revive_config.rs
@@ -1,5 +1,5 @@
 use crate::{
-	Balance, Balances, BalancesCall, Perbill, Runtime, RuntimeCall, RuntimeEvent,
+	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent,
 	RuntimeHoldReason, Timestamp,
 };
 use frame_support::{
@@ -7,14 +7,6 @@ use frame_support::{
 	traits::{ConstBool, ConstU32, ConstU64},
 };
 use frame_system::EnsureSigned;
-
-pub enum AllowBalancesCall {}
-
-impl frame_support::traits::Contains<RuntimeCall> for AllowBalancesCall {
-	fn contains(call: &RuntimeCall) -> bool {
-		matches!(call, RuntimeCall::Balances(BalancesCall::transfer_allow_death { .. }))
-	}
-}
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;
@@ -37,28 +29,17 @@ impl pallet_revive::Config for Runtime {
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	/// The safest default is to allow no calls at all.
-	///
-	/// Runtimes should whitelist dispatchables that are allowed to be called from contracts
-	/// and make sure they are stable. Dispatchables exposed to contracts are not allowed to
-	/// change because that would break already deployed contracts. The `RuntimeCall` structure
-	/// itself is not allowed to change the indices of existing pallets, too.
-	type CallFilter = AllowBalancesCall;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
-	type ChainExtension = ();
+	type Precompiles = ();
 	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type UnsafeUnstableInterface = ConstBool<true>;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	#[cfg(feature = "parachain")]
-	type Xcm = pallet_xcm::Pallet<Self>;
-	#[cfg(not(feature = "parachain"))]
-	type Xcm = ();
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
 	type ChainId = ConstU64<420_420_420>;

--- a/runtime/src/revive_config.rs
+++ b/runtime/src/revive_config.rs
@@ -1,6 +1,5 @@
 use crate::{
-	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeHoldReason, Timestamp,
+	Balance, Balances, Perbill, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, Timestamp,
 };
 use frame_support::{
 	parameter_types,


### PR DESCRIPTION
This PR upgrades `ink-node` to track the latest `polkadot-sdk` main branch instead of using the `stable2503` release.
There are two main reasons for this:
- Missing runtime API:
The new `get_storage_var_key` runtime API https://github.com/paritytech/polkadot-sdk/pull/8274 is not included in the 2503 release. It is expected in `2506`, but in the meantime, having it available in` ink-node` will help tooling teams test against it. _Requested by the Dedot team._

- This also resolves https://github.com/use-ink/ink-node/issues/10, where transactions sent using `polkadot-api` were stuck in the **broadcasted** state. By syncing with the latest changes in `polkadot-sdk`, this issue is resolved.

> Note: This might be a temporary change until the `2506` release, which is expected at the end of this month.
