### PR TITLE
fix(manual-seal): trigger fork-aware tx-pool

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -227,6 +227,7 @@ pub fn run() -> Result<()> {
 						config,
 						cli.finalize_delay_sec.into(),
 					)
+					.await
 					.map_err(sc_cli::Error::Service);
 				}
 


### PR DESCRIPTION
This PR applies the changes from https://github.com/paritytech/polkadot-sdk/pull/9207/files

As per the comments in the code:

> 
> // Seal a first block to trigger fork-aware txpool `maintain`, and create a first
> // view. This is necessary so that sending txs will not keep them in mempool for
> // an undeterminated amount of time.
> //
> // If single state txpool is used there's no issue if we're sealing a first block in
> // advance.