### PR TITLE
Synchronize with `use-ink/polkadot-sdk` branch `pallet-revive-with-system-and-storage-precompiles`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 # repo env variable doesn't work for PR from forks
 env:
   CI_IMAGE: "useink/ci"
-  POLKADOT_SDK_COMMIT: "c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+  POLKADOT_SDK_COMMIT: "7753112a1b6aae323af71e8904fbab02fdc73c22"
   RUST_VERSION: 1.87.0
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 # repo env variable doesn't work for PR from forks
 env:
   CI_IMAGE: "useink/ci"
-  POLKADOT_SDK_COMMIT: "7753112a1b6aae323af71e8904fbab02fdc73c22"
+  POLKADOT_SDK_COMMIT: "a71ec19a94702ea71767ba5ac97603ea6c6305c1"
   RUST_VERSION: 1.87.0
 
 jobs:
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Clone polkadot-sdk
         run: |
-          git clone --depth 100 --branch master https://github.com/paritytech/polkadot-sdk.git
+          git clone --depth 100 --branch master https://github.com/use-ink/polkadot-sdk.git
       - name: Rust Cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
         with:
@@ -115,7 +115,7 @@ jobs:
           apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Clone polkadot-sdk
         run: |
-          git clone --depth 100 --branch master https://github.com/paritytech/polkadot-sdk.git
+          git clone --depth 100 --branch master https://github.com/use-ink/polkadot-sdk.git
       - name: Rust Cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
         with:
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Clone polkadot-sdk
         run: |
-          git clone --depth 100 --branch master https://github.com/paritytech/polkadot-sdk.git
+          git clone --depth 100 --branch master https://github.com/use-ink/polkadot-sdk.git
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@1ccc07ccd54b6048295516a3eb89b192c35057dc # master from 12.09.2024
       - name: Install protobuf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
  "asn1-rs-derive 0.4.0",
  "asn1-rs-impl 0.1.0",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -913,7 +913,7 @@ dependencies = [
  "asn1-rs-derive 0.5.1",
  "asn1-rs-impl 0.2.0",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -929,7 +929,7 @@ dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl 0.2.0",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.12",
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hash-db",
  "log",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1743,7 +1743,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1965,7 +1965,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2023,6 +2023,16 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c06f1eb05f06cf2e380fdded278fbf056a38974299d77960555a311dcf91a52"
+dependencies = [
+ "keccak-const",
+ "sha2-const-stable",
 ]
 
 [[package]]
@@ -2101,6 +2111,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2558,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2583,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2600,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2623,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2670,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2702,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2749,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2759,7 +2778,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api 28.0.0",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-inherents 26.0.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
@@ -2770,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2789,7 +2808,7 @@ dependencies = [
  "sc-network 0.34.0",
  "sp-api 26.0.0",
  "sp-consensus 0.32.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
  "sp-version 29.0.0",
  "tracing",
@@ -2798,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -2838,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support 28.0.0",
@@ -2855,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2872,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2898,7 +2917,7 @@ dependencies = [
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-trie 29.0.0",
  "sp-version 29.0.0",
  "staging-xcm",
@@ -2909,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2920,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -2933,7 +2952,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -2948,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "approx",
  "bounded-collections 0.3.2",
@@ -2974,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-api 26.0.0",
  "sp-consensus-aura 0.32.0",
@@ -2983,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3000,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3014,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-externalities 0.25.0",
  "sp-runtime-interface 24.0.0",
@@ -3024,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents 26.0.0",
@@ -3034,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -3051,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3079,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3099,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3135,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3168,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3182,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3386,7 +3405,7 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs 0.5.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -3400,7 +3419,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -3414,7 +3433,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs 0.7.1",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -3469,7 +3488,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -3511,6 +3530,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3956,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "alloy-core",
 ]
@@ -4225,7 +4245,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fork-tree"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4267,7 +4287,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-support-procedural 23.0.0",
@@ -4291,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4332,7 +4352,7 @@ dependencies = [
  "sp-block-builder 26.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-database 10.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
  "sp-genesis-builder 0.8.0",
  "sp-inherents 26.0.0",
@@ -4355,11 +4375,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
+checksum = "6e56c0e51972d7b26ff76966c4d0f2307030df9daa5ce0885149ece1ab7ca5ad"
 dependencies = [
- "frame-metadata 21.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -4370,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4381,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support 28.0.0",
@@ -4392,13 +4412,13 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-npos-elections",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "aquamarine",
  "frame-support 28.0.0",
@@ -4427,29 +4447,6 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
- "serde",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "frame-metadata"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
@@ -4463,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4502,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4516,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4538,8 +4535,8 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-arithmetic 23.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-genesis-builder 0.8.0",
  "sp-inherents 26.0.0",
  "sp-io 30.0.0",
@@ -4547,7 +4544,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-staking 26.0.0",
  "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-tracing 16.0.0",
  "sp-trie 29.0.0",
  "sp-weights 27.0.0",
@@ -4599,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4612,7 +4609,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "syn 2.0.104",
 ]
 
@@ -4639,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support-procedural-tools-derive 11.0.0",
  "proc-macro-crate 3.3.0",
@@ -4664,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4685,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4704,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -4718,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4728,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "parity-scale-codec",
@@ -5198,7 +5195,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -5915,12 +5911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap-nostd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
-
-[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6097,7 +6087,7 @@ dependencies = [
  "sp-offchain 26.0.0",
  "sp-runtime 31.0.1",
  "sp-session 27.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-transaction-pool 26.0.0",
  "sp-version 29.0.0",
  "staging-parachain-info",
@@ -6634,6 +6624,12 @@ dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "keccak-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
 
 [[package]]
 name = "keccak-hash"
@@ -8082,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "log",
@@ -8101,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -8479,6 +8475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8553,17 +8558,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
 
 [[package]]
 name = "num-format"
@@ -8799,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8817,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8831,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8847,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -8865,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8881,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8896,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8909,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8932,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8953,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8969,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8988,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9013,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9030,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9048,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9066,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9085,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9101,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9116,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9133,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9154,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9167,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9185,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9203,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9225,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9241,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9260,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9275,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9286,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9305,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9317,13 +9311,13 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9342,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9354,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9365,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9375,7 +9369,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9393,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9413,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9423,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9438,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9461,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9478,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9494,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9504,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9522,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9532,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9550,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -9597,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "alloy-core",
  "anyhow",
@@ -9614,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9624,9 +9618,11 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitflags 1.3.2",
+ "const-crypto",
+ "hex-literal",
  "pallet-revive-proc-macro",
  "parity-scale-codec",
  "polkavm-derive 0.27.0",
@@ -9636,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9649,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9666,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9688,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9704,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9721,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9743,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9763,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9780,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "sp-arithmetic 23.0.0",
@@ -9789,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "sp-api 26.0.0",
@@ -9799,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9815,7 +9811,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9830,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9848,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9866,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9881,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9897,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9909,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9928,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9943,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9958,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9972,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9982,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -10007,7 +10003,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -10024,7 +10020,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10420,7 +10416,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10438,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10453,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fatality",
  "futures",
@@ -10476,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10509,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10533,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10556,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10567,7 +10563,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fatality",
  "futures",
@@ -10589,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10603,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10616,7 +10612,7 @@ dependencies = [
  "sc-network 0.34.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-keystore 0.34.0",
  "tracing-gum",
 ]
@@ -10624,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10647,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10665,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10697,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10721,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "futures",
@@ -10740,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10761,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10776,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10798,7 +10794,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10812,7 +10808,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10828,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fatality",
  "futures",
@@ -10846,7 +10842,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10863,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fatality",
  "futures",
@@ -10877,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10894,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -10922,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10935,7 +10931,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10951,7 +10947,7 @@ dependencies = [
  "sc-executor-wasmtime 0.29.0",
  "seccompiler",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
  "sp-io 30.0.0",
  "sp-tracing 16.0.0",
@@ -10962,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10977,7 +10973,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10994,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11019,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11035,7 +11031,7 @@ dependencies = [
  "sp-consensus-babe 0.32.0",
  "sp-consensus-slots 0.32.0",
  "sp-keystore 0.34.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
@@ -11043,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11052,7 +11048,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11080,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fatality",
  "futures",
@@ -11110,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11130,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bounded-collections 0.3.2",
  "derive_more 0.99.20",
@@ -11146,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "bounded-collections 0.3.2",
@@ -11168,14 +11164,14 @@ dependencies = [
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
  "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-rpc"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "mmr-rpc",
@@ -11208,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11258,7 +11254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -11270,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11309,7 +11305,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-session 27.0.0",
  "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
@@ -11318,7 +11314,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11353,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11464,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11484,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12977,7 +12973,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13075,7 +13071,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "polkadot-primitives",
@@ -13235,7 +13231,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -13475,13 +13471,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
-dependencies = [
- "byteorder",
- "derive_more 0.99.20",
-]
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 
 [[package]]
 name = "rw-stream-sink"
@@ -13550,7 +13542,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "sp-core 28.0.0",
@@ -13573,7 +13565,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -13605,7 +13597,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "log",
@@ -13627,7 +13619,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "sp-api 26.0.0",
@@ -13658,13 +13650,13 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
  "memmap2 0.9.7",
  "parity-scale-codec",
- "sc-chain-spec-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sc-chain-spec-derive 11.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sc-client-api 28.0.0",
  "sc-executor 0.32.0",
  "sc-network 0.34.0",
@@ -13673,7 +13665,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-genesis-builder 0.8.0",
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
@@ -13723,7 +13715,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -13734,7 +13726,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -13818,7 +13810,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fnv",
  "futures",
@@ -13832,7 +13824,7 @@ dependencies = [
  "sp-blockchain 28.0.0",
  "sp-consensus 0.32.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-database 10.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
@@ -13872,7 +13864,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -13889,7 +13881,7 @@ dependencies = [
  "sp-arithmetic 23.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-database 10.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "sp-trie 29.0.0",
@@ -13927,7 +13919,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -13976,7 +13968,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "fork-tree 12.0.0",
@@ -14007,7 +13999,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "fork-tree 12.0.0",
@@ -14032,7 +14024,7 @@ dependencies = [
  "sp-consensus-babe 0.32.0",
  "sp-consensus-slots 0.32.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-inherents 26.0.0",
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
@@ -14044,7 +14036,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -14066,7 +14058,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14100,7 +14092,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -14120,7 +14112,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "fork-tree 12.0.0",
  "parity-scale-codec",
@@ -14133,7 +14125,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -14167,7 +14159,7 @@ dependencies = [
  "sp-consensus 0.32.0",
  "sp-consensus-grandpa 13.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
  "substrate-prometheus-endpoint 0.17.0",
@@ -14177,7 +14169,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14197,7 +14189,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14232,7 +14224,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -14255,7 +14247,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -14302,11 +14294,11 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "polkavm 0.26.0",
  "sc-allocator 23.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-wasm-interface 20.0.0",
  "thiserror 1.0.69",
  "wasm-instrument",
@@ -14329,7 +14321,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "polkavm 0.26.0",
@@ -14352,7 +14344,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "anyhow",
  "log",
@@ -14387,7 +14379,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "console",
  "futures",
@@ -14421,7 +14413,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.4",
@@ -14450,7 +14442,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -14508,7 +14500,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14623,7 +14615,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14651,7 +14643,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -14670,7 +14662,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14713,7 +14705,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14785,7 +14777,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -14824,7 +14816,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bs58 0.5.1",
  "bytes",
@@ -14845,7 +14837,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "fnv",
@@ -14879,7 +14871,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint 0.17.0",
@@ -14888,7 +14880,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -14953,7 +14945,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -14994,7 +14986,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15037,7 +15029,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15102,13 +15094,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "sc-executor 0.32.0",
  "sc-executor-common 0.29.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-state-machine 0.35.0",
  "sp-wasm-interface 20.0.0",
  "thiserror 1.0.69",
@@ -15117,7 +15109,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "directories",
@@ -15246,7 +15238,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15269,7 +15261,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "clap",
  "fs4",
@@ -15282,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -15301,7 +15293,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -15314,7 +15306,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-io 30.0.0",
 ]
 
@@ -15343,7 +15335,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "chrono",
  "futures",
@@ -15382,7 +15374,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "chrono",
  "console",
@@ -15441,7 +15433,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15464,7 +15456,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -15481,7 +15473,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
  "sp-tracing 16.0.0",
  "sp-transaction-pool 26.0.0",
@@ -15523,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -15557,7 +15549,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16169,6 +16161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16277,7 +16275,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16322,9 +16320,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.18.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
+checksum = "e16e5723359f0048bf64bfdfba64e5732a56847d42c4fd3fe56f18280c813413"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -16335,21 +16333,21 @@ dependencies = [
  "bs58 0.5.1",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.20",
+ "derive_more 2.0.1",
  "ed25519-zebra 4.0.3",
  "either",
  "event-listener 5.4.0",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "hex",
  "hmac 0.12.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "libm",
  "libsecp256k1",
  "merlin",
- "nom",
+ "nom 8.0.0",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -16368,7 +16366,7 @@ dependencies = [
  "slab",
  "smallvec",
  "soketto 0.8.1",
- "twox-hash",
+ "twox-hash 2.1.1",
  "wasmi",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -16376,25 +16374,25 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.16.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
+checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
 dependencies = [
  "async-channel 2.5.0",
  "async-lock",
  "base64 0.22.1",
  "blake2-rfc",
  "bs58 0.5.1",
- "derive_more 0.99.20",
+ "derive_more 2.0.1",
  "either",
  "event-listener 5.4.0",
  "fnv",
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -16489,7 +16487,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "hash-db",
@@ -16534,7 +16532,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16563,7 +16561,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16589,7 +16587,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16618,7 +16616,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16630,7 +16628,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-api 26.0.0",
  "sp-inherents 26.0.0",
@@ -16651,7 +16649,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16660,7 +16658,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-consensus 0.32.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-database 10.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "thiserror 1.0.69",
@@ -16689,7 +16687,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -16719,7 +16717,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16752,7 +16750,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16789,7 +16787,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16797,7 +16795,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-io 30.0.0",
  "sp-keystore 0.34.0",
  "sp-mmr-primitives",
@@ -16809,7 +16807,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16844,7 +16842,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16867,7 +16865,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -16898,10 +16896,10 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-storage 19.0.0",
  "ss58-registry",
  "substrate-bip39 0.4.7",
@@ -16969,20 +16967,20 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
  "sha2 0.10.9",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -16999,10 +16997,10 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "syn 2.0.104",
 ]
 
@@ -17019,7 +17017,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
@@ -17039,7 +17037,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17049,7 +17047,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17070,7 +17068,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17093,7 +17091,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17120,7 +17118,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "docify",
@@ -17132,7 +17130,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
  "sp-keystore 0.34.0",
  "sp-runtime-interface 24.0.0",
@@ -17173,7 +17171,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
@@ -17194,7 +17192,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -17227,7 +17225,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17236,7 +17234,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17257,7 +17255,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17280,7 +17278,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17289,7 +17287,7 @@ dependencies = [
  "serde",
  "sp-api 26.0.0",
  "sp-core 28.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
@@ -17297,7 +17295,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17310,7 +17308,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-api 26.0.0",
  "sp-core 28.0.0",
@@ -17331,7 +17329,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "backtrace",
  "regex",
@@ -17350,7 +17348,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17371,7 +17369,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17390,7 +17388,7 @@ dependencies = [
  "sp-arithmetic 23.0.0",
  "sp-core 28.0.0",
  "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-trie 29.0.0",
  "sp-weights 27.0.0",
  "tracing",
@@ -17425,7 +17423,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17433,7 +17431,7 @@ dependencies = [
  "polkavm-derive 0.26.0",
  "sp-externalities 0.25.0",
  "sp-runtime-interface-proc-macro 17.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-storage 19.0.0",
  "sp-tracing 16.0.0",
  "sp-wasm-interface 20.0.0",
@@ -17463,7 +17461,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "expander",
@@ -17490,7 +17488,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17519,7 +17517,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17546,7 +17544,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hash-db",
  "log",
@@ -17587,7 +17585,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.3",
@@ -17600,7 +17598,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-externalities 0.25.0",
  "sp-runtime 31.0.1",
  "sp-runtime-interface 24.0.0",
@@ -17642,18 +17640,18 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -17672,7 +17670,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17697,7 +17695,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -17721,7 +17719,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "sp-api 26.0.0",
  "sp-runtime 31.0.1",
@@ -17740,7 +17738,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17769,7 +17767,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ahash 0.8.12",
  "foldhash",
@@ -17818,16 +17816,16 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-version-proc-macro 13.0.0",
  "thiserror 1.0.69",
 ]
@@ -17853,7 +17851,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17877,7 +17875,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17902,7 +17900,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -17910,7 +17908,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic 23.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -17994,7 +17992,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -18007,7 +18005,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.3.2",
@@ -18028,7 +18026,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "environmental",
  "frame-support 28.0.0",
@@ -18052,7 +18050,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18101,16 +18099,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "string-interner"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -18166,7 +18154,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -18204,12 +18192,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18229,7 +18217,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -18272,7 +18260,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -18289,7 +18277,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -18299,7 +18287,7 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker 0.26.0",
  "shlex",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.23",
@@ -18321,14 +18309,14 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
+checksum = "74791ddeaaa6de42e7cc8a715c83eb73303f513f90af701fd07eb2caad92ed84"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "futures",
  "hex",
  "parity-scale-codec",
@@ -18356,9 +18344,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
+checksum = "1728caecd9700391e78cc30dc298221d6f5ca0ea28258a452aa76b0b7c229842"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -18373,15 +18361,15 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
+checksum = "25338dd11ae34293b8d0c5807064f2e00194ba1bd84cccfa694030c8d185b941"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
  "frame-decode",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde 0.5.0",
@@ -18403,9 +18391,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
+checksum = "9097ef356e534ce0b6a50b95233512afc394347b971a4f929c4830adc52bbc6f"
 dependencies = [
  "futures",
  "futures-util",
@@ -18420,9 +18408,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
+checksum = "69516e8ff0e9340a0f21b8398da7f997571af4734ee81deada5150a2668c8443"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -18430,18 +18418,19 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
+ "subxt-metadata",
  "subxt-utils-fetchmetadata",
  "syn 2.0.104",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
+checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
 dependencies = [
  "frame-decode",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -18451,12 +18440,12 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
 dependencies = [
  "derive-where",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "futures",
  "hex",
  "impl-serde 0.5.0",
@@ -18474,9 +18463,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
+checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -18504,9 +18493,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
+checksum = "8c4fb8fd6b16ecd3537a29d70699f329a68c1e47f70ed1a46d64f76719146563"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -19090,7 +19079,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19101,7 +19090,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -19351,6 +19340,12 @@ dependencies = [
  "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typenum"
@@ -19814,42 +19809,43 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
 dependencies = [
  "arrayvec 0.7.6",
  "multi-stash",
- "num-derive",
- "num-traits",
  "smallvec",
  "spin 0.9.8",
  "wasmi_collections",
  "wasmi_core",
- "wasmparser-nostd",
+ "wasmi_ir",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
 name = "wasmi_collections"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
-dependencies = [
- "ahash 0.8.12",
- "hashbrown 0.14.5",
- "string-interner",
-]
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
 
 [[package]]
 name = "wasmi_core"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23b3a7f6c8c3ceeec6b83531ee61f0013c56e51cbf2b14b0f213548b23a4b41"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
 dependencies = [
  "downcast-rs",
  "libm",
- "num-traits",
- "paste",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core",
 ]
 
 [[package]]
@@ -19864,6 +19860,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
@@ -19873,15 +19878,6 @@ dependencies = [
  "indexmap 2.10.0",
  "semver 1.0.26",
  "serde",
-]
-
-[[package]]
-name = "wasmparser-nostd"
-version = "0.100.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
-dependencies = [
- "indexmap-nostd",
 ]
 
 [[package]]
@@ -20365,7 +20361,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20472,7 +20468,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "polkadot-primitives",
@@ -21087,7 +21083,7 @@ dependencies = [
  "data-encoding",
  "der-parser 8.2.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -21104,7 +21100,7 @@ dependencies = [
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -21121,7 +21117,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.12",
@@ -21131,7 +21127,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21142,7 +21138,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
+source = "git+https://github.com/use-ink/polkadot-sdk?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-support 28.0.0",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "ink-node"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "clap",
  "color-print",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "ink-node-runtime"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "deranged",
  "frame-benchmarking",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "ink-parachain-runtime"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "k256",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9ebd288f87aa496179b83471f5b00bcd01def4048714234d3ddbf97a6b9dd2"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,8 +243,31 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec 0.7.6",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743e0fe099fe90a07215ae08413b271b8fac12fca6880c85326ce61341566e6f"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -409,6 +491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +704,35 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -908,22 +1031,10 @@ checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.0",
+ "fastrand",
+ "futures-lite",
  "pin-project-lite 0.2.16",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "blocking",
- "futures-lite 1.13.0",
 ]
 
 [[package]]
@@ -932,29 +1043,9 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "blocking",
- "futures-lite 2.6.0",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.28",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
+ "futures-lite",
 ]
 
 [[package]]
@@ -963,26 +1054,17 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite",
  "parking",
- "polling 3.8.0",
+ "polling",
  "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -998,41 +1080,13 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0434b1ed18ce1cf5769b8ac540e33f01fa9471058b5e89da9e06f3c882a8c12f"
-dependencies = [
- "async-io 1.13.0",
- "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "async-net"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.4.1",
+ "async-io",
  "blocking",
- "futures-lite 2.6.0",
-]
-
-[[package]]
-name = "async-process"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
-dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-signal",
- "blocking",
- "cfg-if",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.44",
- "windows-sys 0.48.0",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1042,14 +1096,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
 dependencies = [
  "async-channel 2.5.0",
- "async-io 2.4.1",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
  "event-listener 5.4.0",
- "futures-lite 2.6.0",
+ "futures-lite",
  "rustix 1.0.7",
  "tracing",
 ]
@@ -1060,8 +1114,8 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
 dependencies = [
- "async-io 2.4.1",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -1139,6 +1193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1218,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
@@ -1224,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "hash-db",
  "log",
@@ -1454,8 +1524,20 @@ dependencies = [
  "async-channel 2.5.0",
  "async-task",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -1495,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1579,6 +1661,21 @@ checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -2313,6 +2410,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2471,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2488,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2511,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2558,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2590,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2610,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2637,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2647,7 +2759,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api 28.0.0",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-inherents 26.0.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
@@ -2658,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2677,7 +2789,7 @@ dependencies = [
  "sc-network 0.34.0",
  "sp-api 26.0.0",
  "sp-consensus 0.32.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
  "sp-version 29.0.0",
  "tracing",
@@ -2686,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -2726,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support 28.0.0",
@@ -2743,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2760,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2786,7 +2898,7 @@ dependencies = [
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-trie 29.0.0",
  "sp-version 29.0.0",
  "staging-xcm",
@@ -2797,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2808,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -2821,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -2836,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "approx",
  "bounded-collections 0.3.2",
@@ -2862,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-api 26.0.0",
  "sp-consensus-aura 0.32.0",
@@ -2871,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2888,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2902,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-externalities 0.25.0",
  "sp-runtime-interface 24.0.0",
@@ -2912,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents 26.0.0",
@@ -2922,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -2939,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -2967,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2987,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3023,29 +3135,23 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "either",
  "futures",
  "futures-timer",
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
- "pin-project",
  "polkadot-overseer",
  "prometheus",
- "rand 0.8.5",
  "sc-client-api 28.0.0",
- "sc-network 0.34.0",
  "sc-rpc-api 0.33.0",
  "sc-service 0.35.0",
  "schnellru",
  "serde",
  "serde_json",
- "smoldot 0.11.0",
- "smoldot-light 0.9.0",
  "sp-authority-discovery",
  "sp-consensus-babe 0.32.0",
  "sp-core 28.0.0",
@@ -3054,9 +3160,7 @@ dependencies = [
  "sp-storage 19.0.0",
  "sp-version 29.0.0",
  "substrate-prometheus-endpoint 0.17.0",
- "thiserror 1.0.69",
  "tokio",
- "tokio-util",
  "tracing",
  "url",
 ]
@@ -3064,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3078,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3126,19 +3230,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -3336,6 +3427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -3864,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "alloy-core",
 ]
@@ -3890,17 +3982,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite 0.2.16",
-]
 
 [[package]]
 name = "event-listener"
@@ -3958,15 +4039,6 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "fastrand"
@@ -4153,7 +4225,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fork-tree"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4195,7 +4267,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-support-procedural 23.0.0",
@@ -4219,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4260,7 +4332,7 @@ dependencies = [
  "sp-block-builder 26.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
  "sp-genesis-builder 0.8.0",
  "sp-inherents 26.0.0",
@@ -4298,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4309,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support 28.0.0",
@@ -4320,13 +4392,13 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-npos-elections",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "aquamarine",
  "frame-support 28.0.0",
@@ -4391,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4430,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4444,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4466,8 +4538,8 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-arithmetic 23.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-genesis-builder 0.8.0",
  "sp-inherents 26.0.0",
  "sp-io 30.0.0",
@@ -4475,7 +4547,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-staking 26.0.0",
  "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-tracing 16.0.0",
  "sp-trie 29.0.0",
  "sp-weights 27.0.0",
@@ -4527,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4540,7 +4612,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "syn 2.0.104",
 ]
 
@@ -4567,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support-procedural-tools-derive 11.0.0",
  "proc-macro-crate 3.3.0",
@@ -4592,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4613,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4632,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -4646,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4656,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "parity-scale-codec",
@@ -4773,26 +4845,11 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite 0.2.16",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -5006,6 +5063,16 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a636fb6a653382a379ee1e5593dacdc628667994167024c143214cafd40c1a86"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "governor"
@@ -5650,12 +5717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5709,7 +5770,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
- "async-io 2.4.1",
+ "async-io",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
@@ -5936,7 +5997,6 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint 0.17.0",
  "try-runtime-cli",
- "wasmtime 8.0.1",
 ]
 
 [[package]]
@@ -6037,7 +6097,7 @@ dependencies = [
  "sp-offchain 26.0.0",
  "sp-runtime 31.0.1",
  "sp-session 27.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-transaction-pool 26.0.0",
  "sp-version 29.0.0",
  "staging-parachain-info",
@@ -6196,26 +6256,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "ittapi"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a5c0b993601cad796222ea076565c5d9f337d35592f8622c753724f06d7271"
-dependencies = [
- "anyhow",
- "ittapi-sys",
- "log",
-]
-
-[[package]]
-name = "ittapi-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7b5e473765060536a660eed127f758cf1a810c73e49063264959c60d1727d9"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "jam-codec"
@@ -7641,12 +7681,6 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
@@ -7759,12 +7793,6 @@ checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
 ]
-
-[[package]]
-name = "lru"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 
 [[package]]
 name = "lru"
@@ -8054,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "log",
@@ -8073,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -8429,12 +8457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8494,6 +8516,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8549,6 +8585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8577,6 +8624,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8716,9 +8785,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8736,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8750,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8766,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -8784,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8800,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8815,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8828,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8851,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8872,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8888,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -8907,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -8932,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8949,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8967,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -8985,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9004,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9020,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9035,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9052,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9073,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9086,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9104,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9122,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9144,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9160,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9179,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9194,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9205,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9224,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9236,13 +9317,13 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
 ]
 
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9261,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9273,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9284,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9294,7 +9375,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9312,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9332,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9342,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9357,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9380,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9397,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9413,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9423,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9441,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9451,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9469,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -9492,10 +9573,11 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
- "polkavm 0.26.0",
- "polkavm-common 0.26.0",
+ "polkavm 0.27.0",
+ "polkavm-common 0.27.0",
  "rand 0.8.5",
  "rand_pcg",
+ "revm",
  "ripemd",
  "rlp 0.6.1",
  "scale-info",
@@ -9515,12 +9597,15 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
+ "alloy-core",
  "anyhow",
  "cargo_metadata",
+ "hex",
  "pallet-revive-uapi",
- "polkavm-linker",
+ "polkavm-linker 0.27.0",
+ "serde_json",
  "sp-core 28.0.0",
  "sp-io 30.0.0",
  "toml 0.8.23",
@@ -9529,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9539,19 +9624,19 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
  "parity-scale-codec",
- "polkavm-derive 0.26.0",
+ "polkavm-derive 0.27.0",
  "scale-info",
 ]
 
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9564,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9581,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9603,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9619,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9636,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9658,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9678,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "frame-system",
@@ -9695,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "sp-arithmetic 23.0.0",
@@ -9704,7 +9789,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "sp-api 26.0.0",
@@ -9714,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9730,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9745,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9763,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9781,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9796,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9812,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9824,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9843,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9858,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9873,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9887,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9897,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -9922,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-benchmarking",
  "frame-support 28.0.0",
@@ -9939,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10226,6 +10311,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10270,7 +10397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -10293,7 +10420,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10311,7 +10438,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10326,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fatality",
  "futures",
@@ -10349,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10382,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10406,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10429,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10440,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fatality",
  "futures",
@@ -10462,7 +10589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10476,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10489,7 +10616,7 @@ dependencies = [
  "sc-network 0.34.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-keystore 0.34.0",
  "tracing-gum",
 ]
@@ -10497,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10520,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10538,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10558,7 +10685,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sc-keystore 25.0.0",
  "schnellru",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "sp-application-crypto 30.0.0",
  "sp-consensus 0.32.0",
  "sp-consensus-slots 0.32.0",
@@ -10570,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -10594,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "futures",
@@ -10613,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10634,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10649,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -10671,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10685,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10701,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fatality",
  "futures",
@@ -10719,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -10736,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fatality",
  "futures",
@@ -10750,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10767,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -10795,7 +10922,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10808,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10824,7 +10951,7 @@ dependencies = [
  "sc-executor-wasmtime 0.29.0",
  "seccompiler",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
  "sp-io 30.0.0",
  "sp-tracing 16.0.0",
@@ -10835,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10850,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10867,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10892,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10902,13 +11029,13 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-keystore 25.0.0",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "serde",
  "sp-application-crypto 30.0.0",
  "sp-consensus-babe 0.32.0",
  "sp-consensus-slots 0.32.0",
  "sp-keystore 0.34.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
@@ -10916,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -10925,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -10953,7 +11080,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fatality",
  "futures",
@@ -10983,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -11003,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bounded-collections 0.3.2",
  "derive_more 0.99.20",
@@ -11019,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "bounded-collections 0.3.2",
@@ -11041,14 +11168,14 @@ dependencies = [
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
  "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-rpc"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "mmr-rpc",
@@ -11081,7 +11208,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11131,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -11143,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11182,7 +11309,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-session 27.0.0",
  "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
@@ -11191,7 +11318,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11226,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11337,7 +11464,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11357,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11391,6 +11518,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef5796e5aaa109df210fed7c6ff82e89c7bf94c28f6332d57bd0efb865fdc2a"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler 0.27.0",
+ "polkavm-common 0.27.0",
+ "polkavm-linux-raw 0.27.0",
+]
+
+[[package]]
 name = "polkavm-assembler"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11404,6 +11544,15 @@ name = "polkavm-assembler"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4859a29e1f4ad64610c4bc2bfc40bb9a535068a034933a5b56b5e7a0febf105a"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "polkavm-assembler"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf3be2911acc089dfe54a92bfec22002f4fbf423b8fa771d1f7e7227f0195f"
 dependencies = [
  "log",
 ]
@@ -11423,9 +11572,19 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
 dependencies = [
- "blake3",
  "log",
  "polkavm-assembler 0.26.0",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19805789e7bf778ac5855f6fe9350353f6a1697c2aab9bfb6fc7c831be54fad"
+dependencies = [
+ "blake3",
+ "log",
+ "polkavm-assembler 0.27.0",
 ]
 
 [[package]]
@@ -11444,6 +11603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
 dependencies = [
  "polkavm-derive-impl-macro 0.26.0",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eea46a17d87cbf3c0f3f6156f6300f60cec67cf9eaca296c770e0873f8389d6"
+dependencies = [
+ "polkavm-derive-impl-macro 0.27.0",
 ]
 
 [[package]]
@@ -11471,6 +11639,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-derive-impl"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abdd1210d96b1dda9ac21199ec469448fd628cea102e2ff0e0df1667c4c3b5f"
+dependencies = [
+ "polkavm-common 0.27.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "polkavm-derive-impl-macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11491,6 +11671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a45173d70138aa1879892c50777ed0d8b0c8556f7678372f09fa1d89bbbddb4"
+dependencies = [
+ "polkavm-derive-impl 0.27.0",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "polkavm-linker"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11502,6 +11692,22 @@ dependencies = [
  "log",
  "object 0.36.7",
  "polkavm-common 0.26.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fe3704d21e96c5d1e6a1b1a43ac57f9dce110d3331fbf8299e9f57d5884066"
+dependencies = [
+ "dirs",
+ "gimli 0.31.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.7",
+ "polkavm-common 0.27.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -11519,20 +11725,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28919f542476f4158cc71e6c072b1051f38f4b514253594ac3ad80e3c0211fc8"
 
 [[package]]
-name = "polling"
-version = "2.8.0"
+name = "polkavm-linux-raw"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite 0.2.16",
- "windows-sys 0.48.0",
-]
+checksum = "061088785efd93e4367faf12f341bb356208c06bab43aa942d472068af80d1c4"
 
 [[package]]
 name = "polling"
@@ -11672,6 +11868,15 @@ checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -12008,17 +12213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -12514,6 +12708,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
+name = "revm"
+version = "27.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6bf82101a1ad8a2b637363a37aef27f88b4efc8a6e24c72bf5f64923dc5532"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90302642d21c8f93e0876e201f3c5f7913c4fcb66fb465b0fd7b707dfe1c79"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1529c8050e663be64010e80ec92bf480315d21b1f2dbf65540028653a621b27d"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78db140e332489094ef314eaeb0bd1849d6d01172c113ab0eb6ea8ab9372926"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9d7d9d71e8a33740b277b602165b6e3d25fff091ba3d7b5a8d373bf55f28a7"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cee3f336b83621294b4cfe84d817e3eef6f3d0fce00951973364cc7f860424d"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-bn254",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "libsecp256k1",
+ "once_cell",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "20.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+dependencies = [
+ "bitflags 2.9.1",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12594,7 +12977,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12692,7 +13075,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "polkadot-primitives",
@@ -12748,6 +13131,18 @@ checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rug"
+version = "1.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
 ]
 
 [[package]]
@@ -12855,20 +13250,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13094,17 +13475,6 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
-dependencies = [
- "byteorder",
- "thiserror-core",
- "twox-hash",
-]
-
-[[package]]
-name = "ruzstd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
@@ -13180,7 +13550,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "sp-core 28.0.0",
@@ -13203,7 +13573,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -13235,7 +13605,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "log",
@@ -13257,7 +13627,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "sp-api 26.0.0",
@@ -13288,13 +13658,13 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
  "memmap2 0.9.7",
  "parity-scale-codec",
- "sc-chain-spec-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sc-chain-spec-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sc-client-api 28.0.0",
  "sc-executor 0.32.0",
  "sc-network 0.34.0",
@@ -13303,7 +13673,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-genesis-builder 0.8.0",
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
@@ -13353,7 +13723,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -13364,7 +13734,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -13448,7 +13818,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fnv",
  "futures",
@@ -13462,7 +13832,7 @@ dependencies = [
  "sp-blockchain 28.0.0",
  "sp-consensus 0.32.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
@@ -13502,7 +13872,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -13519,7 +13889,7 @@ dependencies = [
  "sp-arithmetic 23.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "sp-trie 29.0.0",
@@ -13557,7 +13927,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -13606,12 +13976,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
+ "fork-tree 12.0.0",
  "futures",
  "log",
  "parity-scale-codec",
+ "parking_lot 0.12.4",
  "sc-block-builder 0.33.0",
  "sc-client-api 28.0.0",
  "sc-consensus 0.33.0",
@@ -13635,7 +14007,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "fork-tree 12.0.0",
@@ -13660,7 +14032,7 @@ dependencies = [
  "sp-consensus-babe 0.32.0",
  "sp-consensus-slots 0.32.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-inherents 26.0.0",
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
@@ -13672,7 +14044,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -13694,7 +14066,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -13728,7 +14100,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -13748,7 +14120,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "fork-tree 12.0.0",
  "parity-scale-codec",
@@ -13761,7 +14133,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -13795,7 +14167,7 @@ dependencies = [
  "sp-consensus 0.32.0",
  "sp-consensus-grandpa 13.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
  "substrate-prometheus-endpoint 0.17.0",
@@ -13805,7 +14177,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13825,7 +14197,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13860,7 +14232,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -13883,7 +14255,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -13930,11 +14302,11 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "polkavm 0.26.0",
  "sc-allocator 23.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-wasm-interface 20.0.0",
  "thiserror 1.0.69",
  "wasm-instrument",
@@ -13957,7 +14329,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "polkavm 0.26.0",
@@ -13980,7 +14352,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "anyhow",
  "log",
@@ -14015,7 +14387,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "console",
  "futures",
@@ -14049,7 +14421,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.4",
@@ -14078,7 +14450,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -14136,7 +14508,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14251,7 +14623,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14279,7 +14651,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -14298,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14341,7 +14713,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14413,7 +14785,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -14452,7 +14824,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bs58 0.5.1",
  "bytes",
@@ -14473,7 +14845,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bytes",
  "fnv",
@@ -14507,7 +14879,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint 0.17.0",
@@ -14516,7 +14888,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.9",
@@ -14581,7 +14953,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -14622,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -14665,7 +15037,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -14730,13 +15102,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "sc-executor 0.32.0",
  "sc-executor-common 0.29.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-state-machine 0.35.0",
  "sp-wasm-interface 20.0.0",
  "thiserror 1.0.69",
@@ -14745,7 +15117,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "directories",
@@ -14874,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14897,7 +15269,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "clap",
  "fs4",
@@ -14910,7 +15282,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -14929,7 +15301,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -14942,7 +15314,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-io 30.0.0",
 ]
 
@@ -14971,7 +15343,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "chrono",
  "futures",
@@ -15010,7 +15382,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "chrono",
  "console",
@@ -15069,7 +15441,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15092,7 +15464,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -15109,7 +15481,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-blockchain 28.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
  "sp-tracing 16.0.0",
  "sp-transaction-pool 26.0.0",
@@ -15151,7 +15523,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -15185,7 +15557,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -15357,6 +15729,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15365,22 +15761,6 @@ dependencies = [
  "ahash 0.8.12",
  "cfg-if",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "schnorrkel"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "curve25519-dalek-ng",
- "merlin",
- "rand_core 0.6.4",
- "sha2 0.9.9",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -15496,6 +15876,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand 0.9.1",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15518,6 +15909,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -15662,6 +16062,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -15686,6 +16087,10 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -15872,7 +16277,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -15900,90 +16305,19 @@ dependencies = [
 
 [[package]]
 name = "smol"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
-dependencies = [
- "async-channel 1.9.0",
- "async-executor",
- "async-fs 1.6.0",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-net 1.8.0",
- "async-process 1.8.1",
- "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "smol"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
- "async-fs 2.1.2",
- "async-io 2.4.1",
- "async-lock 3.4.0",
- "async-net 2.0.0",
- "async-process 2.3.1",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
  "blocking",
- "futures-lite 2.6.0",
-]
-
-[[package]]
-name = "smoldot"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bb30cf57b7b5f6109ce17c3164445e2d6f270af2cb48f6e4d31c2967c9a9f5"
-dependencies = [
- "arrayvec 0.7.6",
- "async-lock 2.8.0",
- "atomic-take",
- "base64 0.21.7",
- "bip39",
- "blake2-rfc",
- "bs58 0.5.1",
- "chacha20",
- "crossbeam-queue",
- "derive_more 0.99.20",
- "ed25519-zebra 4.0.3",
- "either",
- "event-listener 2.5.3",
- "fnv",
- "futures-lite 1.13.0",
- "futures-util",
- "hashbrown 0.14.5",
- "hex",
- "hmac 0.12.1",
- "itertools 0.11.0",
- "libsecp256k1",
- "merlin",
- "no-std-net",
- "nom",
- "num-bigint",
- "num-rational",
- "num-traits",
- "pbkdf2",
- "pin-project",
- "poly1305",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "ruzstd 0.4.0",
- "schnorrkel 0.10.2",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3",
- "siphasher 0.3.11",
- "slab",
- "smallvec",
- "soketto 0.7.1",
- "twox-hash",
- "wasmi 0.31.2",
- "x25519-dalek 2.0.1",
- "zeroize",
+ "futures-lite",
 ]
 
 [[package]]
@@ -15993,7 +16327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
 dependencies = [
  "arrayvec 0.7.6",
- "async-lock 3.4.0",
+ "async-lock",
  "atomic-take",
  "base64 0.22.1",
  "bip39",
@@ -16006,7 +16340,7 @@ dependencies = [
  "either",
  "event-listener 5.4.0",
  "fnv",
- "futures-lite 2.6.0",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
@@ -16024,8 +16358,8 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "ruzstd 0.6.0",
- "schnorrkel 0.11.5",
+ "ruzstd",
+ "schnorrkel",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -16035,44 +16369,8 @@ dependencies = [
  "smallvec",
  "soketto 0.8.1",
  "twox-hash",
- "wasmi 0.32.3",
+ "wasmi",
  "x25519-dalek 2.0.1",
- "zeroize",
-]
-
-[[package]]
-name = "smoldot-light"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b5bad1d6b49045e95fe87492ce73d5af81545d8b4d8318a872d2007024c33"
-dependencies = [
- "async-channel 1.9.0",
- "async-lock 2.8.0",
- "base64 0.21.7",
- "blake2-rfc",
- "derive_more 0.99.20",
- "either",
- "event-listener 2.5.3",
- "fnv",
- "futures-channel",
- "futures-lite 1.13.0",
- "futures-util",
- "hashbrown 0.14.5",
- "hex",
- "itertools 0.11.0",
- "log",
- "lru 0.11.1",
- "no-std-net",
- "parking_lot 0.12.4",
- "pin-project",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "siphasher 0.3.11",
- "slab",
- "smol 1.3.0",
- "smoldot 0.11.0",
  "zeroize",
 ]
 
@@ -16083,7 +16381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
 dependencies = [
  "async-channel 2.5.0",
- "async-lock 3.4.0",
+ "async-lock",
  "base64 0.22.1",
  "blake2-rfc",
  "bs58 0.5.1",
@@ -16092,7 +16390,7 @@ dependencies = [
  "event-listener 5.4.0",
  "fnv",
  "futures-channel",
- "futures-lite 2.6.0",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
@@ -16107,8 +16405,8 @@ dependencies = [
  "serde_json",
  "siphasher 1.0.1",
  "slab",
- "smol 2.0.2",
- "smoldot 0.18.0",
+ "smol",
+ "smoldot",
  "zeroize",
 ]
 
@@ -16191,7 +16489,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "hash-db",
@@ -16236,7 +16534,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16265,7 +16563,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16291,7 +16589,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16320,7 +16618,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16332,7 +16630,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-api 26.0.0",
  "sp-inherents 26.0.0",
@@ -16353,7 +16651,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16362,7 +16660,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-consensus 0.32.0",
  "sp-core 28.0.0",
- "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-database 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "thiserror 1.0.69",
@@ -16391,7 +16689,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "futures",
@@ -16421,7 +16719,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16454,7 +16752,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16491,7 +16789,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16499,7 +16797,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-io 30.0.0",
  "sp-keystore 0.34.0",
  "sp-mmr-primitives",
@@ -16511,7 +16809,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16546,7 +16844,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16569,7 +16867,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -16595,15 +16893,15 @@ dependencies = [
  "primitive-types 0.13.1",
  "rand 0.8.5",
  "scale-info",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-storage 19.0.0",
  "ss58-registry",
  "substrate-bip39 0.4.7",
@@ -16642,7 +16940,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "rand 0.8.5",
  "scale-info",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
@@ -16677,7 +16975,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16701,10 +16999,10 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "syn 2.0.104",
 ]
 
@@ -16721,7 +17019,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
@@ -16741,7 +17039,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16751,7 +17049,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16772,7 +17070,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16795,7 +17093,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16822,7 +17120,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bytes",
  "docify",
@@ -16834,7 +17132,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
  "sp-keystore 0.34.0",
  "sp-runtime-interface 24.0.0",
@@ -16875,7 +17173,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
@@ -16896,7 +17194,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -16929,7 +17227,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16938,7 +17236,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -16959,7 +17257,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16982,7 +17280,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16991,7 +17289,7 @@ dependencies = [
  "serde",
  "sp-api 26.0.0",
  "sp-core 28.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
  "thiserror 1.0.69",
 ]
@@ -16999,7 +17297,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17012,7 +17310,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-api 26.0.0",
  "sp-core 28.0.0",
@@ -17033,7 +17331,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "backtrace",
  "regex",
@@ -17052,7 +17350,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17073,7 +17371,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17092,7 +17390,7 @@ dependencies = [
  "sp-arithmetic 23.0.0",
  "sp-core 28.0.0",
  "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-trie 29.0.0",
  "sp-weights 27.0.0",
  "tracing",
@@ -17127,7 +17425,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17135,7 +17433,7 @@ dependencies = [
  "polkavm-derive 0.26.0",
  "sp-externalities 0.25.0",
  "sp-runtime-interface-proc-macro 17.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-storage 19.0.0",
  "sp-tracing 16.0.0",
  "sp-wasm-interface 20.0.0",
@@ -17165,7 +17463,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "Inflector",
  "expander",
@@ -17192,7 +17490,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17221,7 +17519,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17248,7 +17546,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "hash-db",
  "log",
@@ -17289,7 +17587,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.3",
@@ -17302,7 +17600,7 @@ dependencies = [
  "sp-api 26.0.0",
  "sp-application-crypto 30.0.0",
  "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-externalities 0.25.0",
  "sp-runtime 31.0.1",
  "sp-runtime-interface 24.0.0",
@@ -17344,18 +17642,18 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
 ]
 
 [[package]]
@@ -17374,7 +17672,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17399,7 +17697,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -17423,7 +17721,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "sp-api 26.0.0",
  "sp-runtime 31.0.1",
@@ -17442,7 +17740,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17471,7 +17769,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "ahash 0.8.12",
  "foldhash",
@@ -17520,16 +17818,16 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "sp-version-proc-macro 13.0.0",
  "thiserror 1.0.69",
 ]
@@ -17555,7 +17853,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17579,7 +17877,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17604,7 +17902,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -17612,7 +17910,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic 23.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
 ]
 
 [[package]]
@@ -17696,7 +17994,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 28.0.0",
@@ -17709,7 +18007,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.3.2",
@@ -17730,7 +18028,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "environmental",
  "frame-support 28.0.0",
@@ -17754,7 +18052,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17868,11 +18166,11 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "sha2 0.10.9",
  "zeroize",
 ]
@@ -17885,7 +18183,7 @@ checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "sha2 0.10.9",
  "zeroize",
 ]
@@ -17906,12 +18204,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17931,7 +18229,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -17974,7 +18272,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "jsonrpsee 0.24.9",
  "parity-scale-codec",
@@ -17991,7 +18289,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -17999,9 +18297,9 @@ dependencies = [
  "filetime",
  "jobserver",
  "parity-wasm",
- "polkavm-linker",
+ "polkavm-linker 0.26.0",
  "shlex",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22)",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.23",
@@ -18020,12 +18318,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
@@ -18119,7 +18411,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light 0.16.2",
+ "smoldot-light",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -18197,7 +18489,7 @@ dependencies = [
  "parity-scale-codec",
  "pbkdf2",
  "regex",
- "schnorrkel 0.11.5",
+ "schnorrkel",
  "scrypt",
  "secp256k1 0.30.0",
  "secrecy 0.10.3",
@@ -18344,7 +18636,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
@@ -18392,26 +18684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-core"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
-dependencies = [
- "thiserror-core-impl",
-]
-
-[[package]]
-name = "thiserror-core-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -18818,7 +19090,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18829,7 +19101,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -19123,12 +19395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19353,12 +19619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19554,19 +19814,6 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
-dependencies = [
- "smallvec",
- "spin 0.9.8",
- "wasmi_arena",
- "wasmi_core 0.13.0",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "wasmi"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
@@ -19578,15 +19825,9 @@ dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_collections",
- "wasmi_core 0.32.3",
+ "wasmi_core",
  "wasmparser-nostd",
 ]
-
-[[package]]
-name = "wasmi_arena"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_collections"
@@ -19597,18 +19838,6 @@ dependencies = [
  "ahash 0.8.12",
  "hashbrown 0.14.5",
  "string-interner",
-]
-
-[[package]]
-name = "wasmi_core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
-dependencies = [
- "downcast-rs",
- "libm",
- "num-traits",
- "paste",
 ]
 
 [[package]]
@@ -19673,7 +19902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f907fdead3153cb9bfb7a93bbd5b62629472dc06dee83605358c64c52ed3dda9"
 dependencies = [
  "anyhow",
- "async-trait",
  "bincode",
  "cfg-if",
  "indexmap 1.9.3",
@@ -19688,13 +19916,10 @@ dependencies = [
  "target-lexicon 0.12.16",
  "wasmparser 0.102.0",
  "wasmtime-cache",
- "wasmtime-component-macro",
  "wasmtime-cranelift",
  "wasmtime-environ 8.0.1",
- "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-runtime",
- "wat",
  "windows-sys 0.45.0",
 ]
 
@@ -19770,27 +19995,6 @@ dependencies = [
  "windows-sys 0.45.0",
  "zstd 0.11.2+zstd.1.5.2",
 ]
-
-[[package]]
-name = "wasmtime-component-macro"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267096ed7cc93b4ab15d3daa4f195e04dbb7e71c7e5c6457ae7d52e9dd9c3607"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e02ca7a4a3c69d72b88f26f0192e333958df6892415ac9ab84dcc42c9000c2"
 
 [[package]]
 name = "wasmtime-cranelift"
@@ -19871,19 +20075,6 @@ dependencies = [
  "wasm-encoder",
  "wasmparser 0.235.0",
  "wasmprinter",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab182d5ab6273a133ab88db94d8ca86dc3e57e43d70baaa4d98f94ddbd7d10a"
-dependencies = [
- "cc",
- "cfg-if",
- "rustix 0.36.17",
- "wasmtime-asm-macros",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -20038,7 +20229,6 @@ dependencies = [
  "cfg-if",
  "cpp_demangle 0.3.5",
  "gimli 0.27.3",
- "ittapi",
  "log",
  "object 0.30.4",
  "rustc-demangle",
@@ -20093,7 +20283,6 @@ dependencies = [
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ 8.0.1",
- "wasmtime-fiber",
  "wasmtime-jit-debug",
  "windows-sys 0.45.0",
 ]
@@ -20108,39 +20297,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "wasmparser 0.102.0",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983db9cc294d1adaa892a53ff6a0dc6605fc0ab1a4da5d8a2d2d4bde871ff7dd"
-dependencies = [
- "anyhow",
- "heck 0.4.1",
- "wit-parser",
-]
-
-[[package]]
-name = "wast"
-version = "235.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda4293f626c99021bb3a6fbe4fbbe90c0e31a5ace89b5f620af8925de72e13"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width",
- "wasm-encoder",
-]
-
-[[package]]
-name = "wat"
-version = "1.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e777e0327115793cb96ab220b98f85327ec3d11f34ec9e8d723264522ef206aa"
-dependencies = [
- "wast",
 ]
 
 [[package]]
@@ -20209,7 +20365,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20316,7 +20472,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "polkadot-primitives",
@@ -20883,21 +21039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f887c3da527a51b321076ebe6a7513026a4757b6d4d144259946552d6fc728b3"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 1.9.3",
- "log",
- "pulldown-cmark",
- "unicode-xid",
- "url",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20990,7 +21131,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21001,7 +21142,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=7753112a1b6aae323af71e8904fbab02fdc73c22#7753112a1b6aae323af71e8904fbab02fdc73c22"
 dependencies = [
  "frame-support 28.0.0",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
-version = "0.44.0"
+version = "0.45.0"
 license = "Unlicense"
 homepage = "https://use.ink"
 repository = "https://github.com/use-ink/ink-node"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,108 +31,108 @@ smallvec = "1.11.0"
 color-print = "0.3.4"
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-support-procedural = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "substrate-prometheus-endpoint", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+frame-benchmarking = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+frame-executive = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-support = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-support-procedural = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-system = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-try-runtime = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-aura = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-authorship = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-balances = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-session = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-sudo = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-timestamp = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-message-queue = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sc-basic-authorship = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-chain-spec = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-cli = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-client-api = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-consensus = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-executor = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-network = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-network-sync = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-offchain = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-rpc = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-service = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-sysinfo = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-telemetry = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-tracing = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-transaction-pool = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sc-transaction-pool-api = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sp-api = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-keyring = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-block-builder = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-blockchain = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sp-consensus-aura = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-core = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-inherents = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-keystore = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sp-offchain = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-runtime = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-session = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-std = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-timestamp = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sp-transaction-pool = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-version = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+prometheus-endpoint = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", package = "substrate-prometheus-endpoint", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+substrate-build-script-utils = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
 try-runtime-cli = { version = "0.42.0" }
 
 # extra deps for running a solo node on top of a parachain
-pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-grandpa = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-genesis-builder = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-storage = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sc-consensus-aura = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 # extra deps for setting up pallet-revive
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false, features = ["scale", "$unstable-hostfn"] }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-assets = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-revive-uapi = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["scale", "$unstable-hostfn"] }
+pallet-utility = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm", default-features = false }
-xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+polkadot-cli = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+polkadot-parachain-primitives = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+polkadot-primitives = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+polkadot-runtime-common = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+xcm = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", package = "staging-xcm", default-features = false }
+xcm-builder = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-client-consensus-proposer ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-client-consensus-common ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
-pallet-collator-selection = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-parachain-info", default-features = false }
-parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-client-cli = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-client-collator = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-client-consensus-proposer ={ git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-client-consensus-aura = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-client-consensus-common ={ git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-client-service = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-pallet-aura-ext = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+cumulus-primitives-timestamp = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+pallet-collator-selection = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+parachain-info = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", package = "staging-parachain-info", default-features = false }
+parachains-common = { git = "https://github.com/use-ink/polkadot-sdk", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,111 +29,110 @@ scale-info = { version = "2.11.6", default-features = false, features = [
 ] }
 smallvec = "1.11.0"
 color-print = "0.3.4"
-wasmtime = "8.0.1"
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-support-procedural = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", package = "substrate-prometheus-endpoint", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-support-procedural = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-network = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "substrate-prometheus-endpoint", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
 try-runtime-cli = { version = "0.42.0" }
 
 # extra deps for running a solo node on top of a parachain
-pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
 
 # extra deps for setting up pallet-revive
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["scale", "$unstable-hostfn"] }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false, features = ["scale", "$unstable-hostfn"] }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", package = "staging-xcm", default-features = false }
-xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm", default-features = false }
+xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-client-consensus-proposer ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-client-consensus-common ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-pallet-collator-selection = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", package = "staging-parachain-info", default-features = false }
-parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-client-consensus-proposer ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-client-consensus-common ={ git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22" }
+pallet-collator-selection = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }
+parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", package = "staging-parachain-info", default-features = false }
+parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", rev = "7753112a1b6aae323af71e8904fbab02fdc73c22", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -28,8 +28,8 @@ serde_json = { workspace = true }
 # Local
 ink-parachain-runtime = { path = "../parachain-runtime", features = [
   "parachain",
-], version = "0.44.0" }
-ink-node-runtime = { path = "../runtime", version = "0.44.0" }
+], version = "0.45.0" }
+ink-node-runtime = { path = "../runtime", version = "0.45.0" }
 
 # Substrate
 frame-benchmarking = { workspace = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,6 @@ serde = { workspace = true }
 jsonrpsee = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }
-wasmtime = { workspace = true }
 
 # Local
 ink-parachain-runtime = { path = "../parachain-runtime", features = [

--- a/parachain-runtime/src/revive_config.rs
+++ b/parachain-runtime/src/revive_config.rs
@@ -34,6 +34,7 @@ impl pallet_revive::Config for Runtime {
 	type DepositPerByte = DepositPerByte;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
+	type Precompiles = (ERC20<Self, InlineIdConfig<0x120>, ()>, XcmPrecompile<Self>);
 	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
@@ -46,5 +47,5 @@ impl pallet_revive::Config for Runtime {
 	type NativeToEthRatio = ConstU32<100_000_000>; // 10^(18 - 10) Eth is 10^18, Native is 10^10.
 	type EthGasEncoder = ();
 	type FindAuthor = <Runtime as pallet_authorship::Config>::FindAuthor;
-	type Precompiles = (ERC20<Self, InlineIdConfig<0x120>, ()>, XcmPrecompile<Self>);
+	type AllowEVMBytecode = ConstBool<false>;
 }

--- a/runtime/src/revive_config.rs
+++ b/runtime/src/revive_config.rs
@@ -46,4 +46,5 @@ impl pallet_revive::Config for Runtime {
 	type NativeToEthRatio = ConstU32<100_000_000>; // 10^(18 - 10) Eth is 10^18, Native is 10^10.
 	type EthGasEncoder = ();
 	type FindAuthor = <Runtime as pallet_authorship::Config>::FindAuthor;
+	type AllowEVMBytecode = ConstBool<false>;
 }


### PR DESCRIPTION
* Synchronizes `ink-node` with https://github.com/use-ink/polkadot-sdk/tree/pallet-revive-with-system-and-storage-precompiles, until the two pre-compile PRs are merged into `polkadot-sdk`.
* Bumpversion to 0.45.0